### PR TITLE
Modified .bool to work under the limitations of Swift MySQL driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .build
 Packages
 *.xcodeproj
+.DS_Store

--- a/Sources/FluentMySQL/MySQLSerializer.swift
+++ b/Sources/FluentMySQL/MySQLSerializer.swift
@@ -19,7 +19,7 @@ public final class MySQLSerializer: GeneralSQLSerializer {
         case .double:
             return "DOUBLE"
         case .bool:
-            return "BIT"
+            return "TINYINT"
         case .data:
             return "BLOB"
         }


### PR DESCRIPTION
Currently, [vapor/mysql](https://github.com/vapor/mysql) doesn't support bitfields for deserialization. Which means that `let mybool: Bool = node.extract("myBool")` will fail and be caught by [vapor/mysql/Bind+Node.swift:105](https://github.com/vapor/mysql/blob/master/Sources/MySQL/Bind%2BNode.swift#L105).

There are quite a few ways to solve this problem. The most involved being implement bit fields in `vapor/mysql`. It's also possible to just implement bit fields for booleans by adding the case `case MYSQL_TYPE_BIT where cBind.buffer_length == 1:` and returning an `Int`/`UInt` and then let `Node` automatically turn that into a boolean, but it seems a little bit silly to me to implement the case only to catch single-bit `BIT` fields. Then, there's the simplest solution: this `PR`. Just change the type from `BIT` to `TINYINT` until `vapor/mysql` supports `BIT`.   
