### PR TITLE
Custom encoding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,7 @@ import PackageDescription
 let package = Package(
     name: "FluentMySQL",
     dependencies: [
-//   		.Package(url: "https://github.com/vapor/mysql.git", majorVersion: 0, minor: 4),
-        .Package(url: "../mysql/", majorVersion: 0, minor: 4),
+   		.Package(url: "https://github.com/vapor/mysql.git", majorVersion: 0, minor: 4),
    		.Package(url: "https://github.com/vapor/fluent.git", majorVersion: 0, minor: 9),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,8 @@ import PackageDescription
 let package = Package(
     name: "FluentMySQL",
     dependencies: [
-   		.Package(url: "https://github.com/vapor/mysql.git", majorVersion: 0, minor: 4),
+//   		.Package(url: "https://github.com/vapor/mysql.git", majorVersion: 0, minor: 4),
+        .Package(url: "../mysql/", majorVersion: 0, minor: 4),
    		.Package(url: "https://github.com/vapor/fluent.git", majorVersion: 0, minor: 9),
     ]
 )

--- a/Sources/FluentMySQL/MySQLDriver.swift
+++ b/Sources/FluentMySQL/MySQLDriver.swift
@@ -33,6 +33,9 @@ public class MySQLDriver: Fluent.Driver {
      the string specifies the socket or named pipe to use.
      - parameter flag: Usually 0, but can be set to a combination of the
      flags at http://dev.mysql.com/doc/refman/5.7/en/mysql-real-connect.html
+     - parameter encoding: Usually "utf8", but something like "utf8mb4" may be
+        used, since "utf8" does not fully implement the UTF8 standard and does
+        not support Unicode.
      
      
      - throws: `Error.connection(String)` if the call to
@@ -44,7 +47,8 @@ public class MySQLDriver: Fluent.Driver {
         password: String,
         database: String,
         port: UInt = 3306,
-        flag: UInt = 0
+        flag: UInt = 0,
+        encoding: String = "utf8"
         ) throws {
         self.database = try MySQL.Database(
             host: host,
@@ -52,7 +56,8 @@ public class MySQLDriver: Fluent.Driver {
             password: password,
             database: database,
             port: port,
-            flag: flag
+            flag: flag,
+            encoding: encoding
         )
     }
     

--- a/Sources/FluentMySQL/MySQLSerializer.swift
+++ b/Sources/FluentMySQL/MySQLSerializer.swift
@@ -14,7 +14,7 @@ public final class MySQLSerializer: GeneralSQLSerializer {
             if let length = length {
                 return "VARCHAR(\(length))"
             } else {
-                return "VARCHAR(255)"
+                return "VARCHAR(255)" // TODO: This may need to be 191 if using `utf8mb4` encoding
             }
         case .double:
             return "DOUBLE"


### PR DESCRIPTION
Note: You will still need to manually alter tables to support this encoding. See vapor/fluent#74.
