### PR TITLE
Implements count functionality to queries

### DIFF
--- a/Sources/FluentMySQL/MySQLDriver.swift
+++ b/Sources/FluentMySQL/MySQLDriver.swift
@@ -94,6 +94,14 @@ public class MySQLDriver: Fluent.Driver {
                 return id
             }
         }
+        else if query.action == .count {
+            // Get the first row and first column value as int
+            // (which should be the count, otherwise use 0)
+            let integer = results
+                .nodeArray?.first?
+                .nodeObject?.first?.1.int ?? 0
+            return .number(.int(integer))
+        }
         
         return results
     }


### PR DESCRIPTION
This is part of a series of pull requests to implement the count functionality for queries in Fluent. This addition allows to quickly determine the number of results of a query, without retrieving and parsing any data from the database.

There is also a pull request for Fluent (vapor/fluent#115).
