### PR TITLE
Fixes last insert id when uuid/int types mixed

### DIFF
--- a/Sources/MySQLDriver/MySQLConnection.swift
+++ b/Sources/MySQLDriver/MySQLConnection.swift
@@ -31,7 +31,7 @@ public final class Connection: Fluent.Connection {
             let (statement, values) = serializer.serialize()
             let results = try mysql(statement, values)
             
-            if query.action == .create {
+            if case .int = E.idType, query.action == .create {
                 let insert = try mysql("SELECT LAST_INSERT_ID() as id", [])
                 if
                     case .array(let array) = insert.wrapped,


### PR DESCRIPTION
Resolves #39.

Only call `LAST_INSERT_ID` when the idType is `.int`.