### PR TITLE
delete limit fix

### DIFF
--- a/Sources/MySQLDriver/MySQLSerializer.swift
+++ b/Sources/MySQLDriver/MySQLSerializer.swift
@@ -63,4 +63,25 @@ public final class MySQLSerializer<E: Entity>: GeneralSQLSerializer<E> {
             []
         )
     }
+    
+    public override func limit(_ limit: RawOr<Limit>) -> String {
+        var statement: [String] = []
+        
+        statement += "LIMIT"
+        switch limit {
+        case .raw(let raw, _):
+            statement += raw
+        case .some(let some):
+            if query.action == .delete {
+                if some.offset != 0 {
+                    print("[Fluent] [Warning] You cannot specify offsets in a delete query.")
+                }
+                statement += "\(some.count)"
+            } else {
+                statement += "\(some.offset), \(some.count)"
+            }
+        }
+        
+        return statement.joined(separator: " ")
+    }
 }

--- a/Tests/MySQLDriverTests/FluentMySQLTests.swift
+++ b/Tests/MySQLDriverTests/FluentMySQLTests.swift
@@ -33,7 +33,7 @@ class FluentMySQLTests: XCTestCase {
         try database.create(Atom.self) { atoms in
             atoms.id()
             atoms.string("name")
-            atoms.foreignKey(foreignIdKey: "name", referencesIdKey: "foo", on: Compound.self)
+            atoms.foreignKey("name", references: "foo", on: Compound.self)
         }
         try database.index("name", for: Atom.self)
     }


### PR DESCRIPTION
`OFFSET` is not allowed in `DELETE` clauses in MySQL (https://stackoverflow.com/questions/7142097/mysql-delete-statement-with-limit).

This pull request overrides the limit method to leave out the offset parameter. Since the method is not throwing, a print warning is given instead if the user attempts to provide an offset to a delete query.