### PR TITLE
Log transaction start, commit, and rollback events

### DIFF
--- a/Sources/MySQLDriver/MySQLDriver.swift
+++ b/Sources/MySQLDriver/MySQLDriver.swift
@@ -146,7 +146,15 @@ extension Driver: Transactable {
         return try conn.transaction {
             let wrapped = MySQLDriver.Connection(conn)
             wrapped.queryLogger = self.queryLogger
-            return try closure(wrapped)
+            wrapped.queryLogger?.log("START TRANSACTION", [])
+            do {
+                let result = try closure(wrapped)
+                wrapped.queryLogger?.log("COMMIT", [])
+                return result
+            } catch {
+                wrapped.queryLogger?.log("ROLLBACK", [])
+                throw error
+            }
         }
     }
 }


### PR DESCRIPTION
Transactions are not currently logged; this makes testing that transactions were properly applied to a given operation more difficult. This PR adds simple logging of transactions. Logging these up at the Fluent level might be a better solution in the long term since it would cover all drivers that support transactions, not just MySQL.