### PR TITLE
Incorrect `id` returned when executing a `create` query with an identifier already set

### DIFF
--- a/Sources/MySQLDriver/MySQLConnection.swift
+++ b/Sources/MySQLDriver/MySQLConnection.swift
@@ -32,6 +32,9 @@ public final class Connection: Fluent.Connection {
             let results = try mysql(statement, values)
             
             if case .int = E.idType, query.action == .create {
+                if let id = query.entity?.id {
+                    return Node(id)
+                }
                 let insert = try mysql("SELECT LAST_INSERT_ID() as id", [])
                 if
                     case .array(let array) = insert.wrapped,


### PR DESCRIPTION
Currently, a model with an integer identifier that is explicitly specified will have an incorrect identifier set after `try model.save()` is called.

For this model:

```swift
final class Thing: Model {
  init(id: Int) {
    self.id = Identifier(id)
  }
}
```

with this table:

```sql
CREATE TABLE `thing` (
  `id` int(11) NOT NULL,
  PRIMARY KEY (`id`)
)
```

the following test will fail:

```swift
let obj = Thing(id: 42)
XCTAssertEqual(obj.id, 42) // Pass: Id set correctly
try obj.save()
XCTAssertEqual(obj.id, 42) // Fail: Id overwritten with a different int
let reloaded = try Thing.find(42)
XCTAssertNotNil(reloaded) // Pass: Id was stored correctly
```

This is because of [this code block](https://github.com/vapor/mysql-driver/blob/master/Sources/MySQLDriver/MySQLConnection.swift#L34-L44). The ID is always overwritten by the results of `LAST_INSERT_ID()`, however if the ID was passed in, then `LAST_INSERT_ID()` will give the result of an earlier insert operation, thus overwriting the model's correct ID with an incorrect one.

This PR fixes this by returning the entity's own ID if one was provided.