### PR TITLE
Adds URL init for MySQLDatabase

### DIFF
--- a/Sources/FluentMySQL/MySQLDatabase.swift
+++ b/Sources/FluentMySQL/MySQLDatabase.swift
@@ -33,6 +33,18 @@ public final class MySQLDatabase: Service {
         self.password = password
         self.database = database
     }
+    
+    /// Initialize MySQLDatabase with a DB URL
+    public convenience init(databaseURL: String) {
+        let tokens = databaseURL
+            .replacingOccurrences(of: "mysql://", with: "")
+            .replacingOccurrences(of: "?reconnect=true", with: "")
+            .split { ["@", "/", ":"].contains(String($0)) }
+        
+        let (username, password, host, database) = (String(tokens[0]), String(tokens[1]), String(tokens[2]), String(tokens[3]))
+        
+        self.init(hostname: host, user: username, password: password, database: database)
+    }
 }
 
 // MARK: Database

--- a/Sources/FluentMySQL/MySQLDatabase.swift
+++ b/Sources/FluentMySQL/MySQLDatabase.swift
@@ -35,15 +35,16 @@ public final class MySQLDatabase: Service {
     }
     
     /// Initialize MySQLDatabase with a DB URL
-    public convenience init(databaseURL: String) {
-        let tokens = databaseURL
-            .replacingOccurrences(of: "mysql://", with: "")
-            .replacingOccurrences(of: "?reconnect=true", with: "")
-            .split { ["@", "/", ":"].contains(String($0)) }
+    public convenience init?(databaseURL: String) {
+        guard let url = URL(string: databaseURL),
+            url.pathComponents.count >= 2,
+            let hostname = url.host,
+            let username = url.user,
+            let password = url.password
+            else {return nil}
         
-        let (username, password, host, database) = (String(tokens[0]), String(tokens[1]), String(tokens[2]), String(tokens[3]))
-        
-        self.init(hostname: host, user: username, password: password, database: database)
+        let database = url.pathComponents[1]
+        self.init(hostname: hostname, user: username, password: password, database: database)
     }
 }
 

--- a/Sources/FluentMySQL/MySQLDatabase.swift
+++ b/Sources/FluentMySQL/MySQLDatabase.swift
@@ -37,6 +37,7 @@ public final class MySQLDatabase: Service {
     /// Initialize MySQLDatabase with a DB URL
     public convenience init?(databaseURL: String) {
         guard let url = URL(string: databaseURL),
+            url.scheme == "mysql",
             url.pathComponents.count >= 2,
             let hostname = url.host,
             let username = url.user,

--- a/Sources/FluentMySQL/MySQLDatabase.swift
+++ b/Sources/FluentMySQL/MySQLDatabase.swift
@@ -38,12 +38,12 @@ public final class MySQLDatabase: Service {
     public convenience init?(databaseURL: String) {
         guard let url = URL(string: databaseURL),
             url.scheme == "mysql",
-            url.pathComponents.count >= 2,
+            url.pathComponents.count == 2,
             let hostname = url.host,
-            let username = url.user,
-            let password = url.password
+            let username = url.user
             else {return nil}
-        
+
+        let password = url.password
         let database = url.pathComponents[1]
         self.init(hostname: hostname, user: username, password: password, database: database)
     }


### PR DESCRIPTION
Allows you to do something like 
```
let databaseURL: String = "mysql://user:pass@us-cdbr-east.cleardb.com/DATABASE"
let db = MySQLDatabase(databaseURL: databaseURL)
```

or

```
if let databaseURL = ProcessInfo.processInfo.environment["DATABASE_URL"] {
    db = MySQLDatabase(databaseURL: databaseURL)
}
```

Which is necessary if you're going to be connecting to a MySQL DB from Heroku