### PR TITLE
Changed TINYINT length for Bool values

### DIFF
--- a/Sources/FluentMySQL/MySQLDatabase+Schema.swift
+++ b/Sources/FluentMySQL/MySQLDatabase+Schema.swift
@@ -56,7 +56,7 @@ public protocol MySQLColumnRepresentable {
 }
 
 extension Bool: MySQLColumnRepresentable {
-    public static var mysqlColumn: ColumnType { return .uint8() }
+    public static var mysqlColumn: ColumnType { return .uint8(length: 1) }
 }
 
 extension String: MySQLColumnRepresentable {


### PR DESCRIPTION
Use `TINYINT` with `length = 1` instead of `length = 4`