### PR TITLE
Fixed #109 & added tests for FKs and Index counts

### DIFF
--- a/Sources/FluentMySQL/MySQLDatabase+QuerySupporting.swift
+++ b/Sources/FluentMySQL/MySQLDatabase+QuerySupporting.swift
@@ -80,7 +80,8 @@ extension MySQLDatabase: QuerySupporting, CustomSQLSupporting {
                 return Future.map(on: connection) { model }
             }
         case .didCreate:
-            if M.ID.self == Int.self {
+            // only use last_id if the model's current ID is null, otherwise keep it
+            if model.fluentID == nil, M.ID.self == Int.self {
                 return connection.simpleQuery("SELECT LAST_INSERT_ID() AS lastval;").map(to: M.self) { row in
                     var model = model
                     try model.fluentID = row[0].firstValue(forColumn: "lastval")?.decode(Int.self) as? M.ID

--- a/Sources/FluentMySQL/MySQLDatabase+QuerySupporting.swift
+++ b/Sources/FluentMySQL/MySQLDatabase+QuerySupporting.swift
@@ -80,7 +80,7 @@ extension MySQLDatabase: QuerySupporting, CustomSQLSupporting {
                 return Future.map(on: connection) { model }
             }
         case .didCreate:
-            // only use last_id if the model's current ID is null, otherwise keep it
+            // only use last_id if the model's current ID is nil, otherwise keep it
             if model.fluentID == nil, M.ID.self == Int.self {
                 return connection.simpleQuery("SELECT LAST_INSERT_ID() AS lastval;").map(to: M.self) { row in
                     var model = model

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -306,6 +306,11 @@ struct Pet: MySQLJSONType {
 final class Parent: MySQLModel, Migration {
     var id: Int?
     var name: String
+    
+    init(id: Int?, name: String) {
+        self.id = id
+        self.name = name
+    }
 }
 
 final class Child: MySQLModel, Migration {
@@ -313,6 +318,12 @@ final class Child: MySQLModel, Migration {
     var name: String
     var parentId: Int
 
+    init(id: Int?, name: String, parentId: Int) {
+        self.id = id
+        self.name = name
+        self.parentId = parentId
+    }
+    
     static func prepare(on connection: MySQLDatabase.Connection) -> Future<Void> {
         return Database.create(self, on: connection, closure: { builder in
             try addProperties(to: builder)

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -216,8 +216,8 @@ class FluentMySQLTests: XCTestCase {
         try Parent.prepare(on: conn).wait()
         try Child.prepare(on: conn).wait()
         // Save Pet
-        let parent = Parent(id: 64, name: "Snuffles")
-        let savedParent = try parent.create(on: conn).wait()
+        var parent = Parent(id: 64, name: "Snuffles")
+        parent = try parent.create(on: conn).wait()
         // Save User with a ref to previously saved Pet
         var child = Child(id: nil, name: "Morty", parentId: parent.id!)
         child = try child.create(on: conn).wait()
@@ -303,12 +303,12 @@ struct Pet: MySQLJSONType {
     var name: String
 }
 
-struct Parent: MySQLModel, Migration {
+final class Parent: MySQLModel, Migration {
     var id: Int?
     var name: String
 }
 
-struct Child: MySQLModel, Migration {
+final class Child: MySQLModel, Migration {
     var id: Int?
     var name: String
     var parentId: Int

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -222,7 +222,7 @@ class FluentMySQLTests: XCTestCase {
         parent = try parent.create(on: conn).wait()
         // Save Child with a ref to previously saved Parent
         let savedParent = try Parent.query(on: conn).first().wait()
-//        XCTAssertEqual(savedParent!.id!, parent.id!)
+        XCTAssertEqual(savedParent!.id!, parent.id!, "Fetched ID \(savedParent!.id!) != saved ID \(parent.id!)")
         print("Parent saved with ID", savedParent?.id ?? "NOT SAVED")
         var child = Child(id: nil, name: "Morty", parentId: savedParent!.id!)
         child = try child.save(on: conn).wait()

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -216,8 +216,8 @@ class FluentMySQLTests: XCTestCase {
         try Parent.prepare(on: conn).wait()
         try Child.prepare(on: conn).wait()
         // Save Pet
-        var parent = Parent(id: 64, name: "Snuffles")
-        parent = try parent.create(on: conn).wait()
+        let parent = Parent(id: 64, name: "Snuffles")
+        let savedParent = try parent.create(on: conn).wait()
         // Save User with a ref to previously saved Pet
         var child = Child(id: nil, name: "Morty", parentId: parent.id!)
         child = try child.create(on: conn).wait()

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -95,7 +95,6 @@ class FluentMySQLTests: XCTestCase {
         _ = try conn.simpleQuery("insert into tablea values (3, 3);").wait()
         _ = try conn.simpleQuery("insert into tablea values (4, 4);").wait()
 
-
         let all = try A.query(on: conn)
             .customSQL { sql in
                 switch sql {

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -211,8 +211,10 @@ class FluentMySQLTests: XCTestCase {
         defer { benchmarker.pool.releaseConnection(conn) }
 
         // Prep tables
-        defer { try? Child.revert(on: conn).wait()
-                try? Parent.revert(on: conn).wait() }
+        defer {
+        	try? Child.revert(on: conn).wait()
+			try? Parent.revert(on: conn).wait()
+		}
         try Parent.prepare(on: conn).wait()
         try Child.prepare(on: conn).wait()
         MySQLDatabase.enableLogging(conn.logger!, on: conn)
@@ -240,12 +242,16 @@ class FluentMySQLTests: XCTestCase {
         defer { benchmarker.pool.releaseConnection(conn) }
 
         // Prep tables
-        defer { try? Child.revert(on: conn).wait()
-                try? Parent.revert(on: conn).wait() }
+        defer {
+        	try? Child.revert(on: conn).wait()
+			try? Parent.revert(on: conn).wait()
+		}
         try Parent.prepare(on: conn).wait()
         try Child.prepare(on: conn).wait()
 
         let testDatabase = database.config.database
+        // Fetch how many contraints were created in Child, ignoring primary keys
+        // Should be 1 (Parent-Child foreign key)
         let query = "select COUNT(1) as resultCount from information_schema.KEY_COLUMN_USAGE where table_schema = '\(testDatabase)' and table_name = '\(Child.entity)' and constraint_name != 'PRIMARY'"
 
         // conn.all(CountResult.self, in: query).wait() has been removed

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -218,10 +218,13 @@ class FluentMySQLTests: XCTestCase {
         try Child.prepare(on: conn).wait()
         MySQLDatabase.enableLogging(conn.logger!, on: conn)
         // Save Parent
-        var parent = Parent(id: 64, name: "Snuffles")
-        parent = try parent.save(on: conn).wait()
+        var parent = Parent(id: 64, name: "Jerry")
+        parent = try parent.create(on: conn).wait()
         // Save Child with a ref to previously saved Parent
-        var child = Child(id: nil, name: "Morty", parentId: parent.id!)
+        let savedParent = try Parent.query(on: conn).first().wait()
+//        XCTAssertEqual(savedParent!.id!, parent.id!)
+        print("Parent saved with ID", savedParent?.id ?? "NOT SAVED")
+        var child = Child(id: nil, name: "Morty", parentId: savedParent!.id!)
         child = try child.save(on: conn).wait()
 
         if let fetched = try Child.query(on: conn).first().wait() {

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -16,9 +16,9 @@ class FluentMySQLTests: XCTestCase {
         let config = MySQLDatabaseConfig(
             hostname: "localhost",
             port: 3306,
-            username: "test",
-            password: "test",
-            database: "vapor_test"
+            username: "vapor_username",
+            password: "vapor_password",
+            database: "vapor_database"
         )
         database = MySQLDatabase(config: config)
         benchmarker = Benchmarker(database, on: eventLoop, onFail: XCTFail)


### PR DESCRIPTION
- [x] Fixes #109
- [x] Added test cases for Parent child relationship
- [x] Added test cases to detect dupe foreign keys (related to for https://github.com/vapor/fluent/issues/386)

The model is pretty much the same as in vapor/fluent-postgresql

Moved `database` to allow reuse.

 (Fu&$& up last PR)
