### PR TITLE
Add convenience protocol for enums

### DIFF
--- a/Sources/FluentMySQL/MySQLType.swift
+++ b/Sources/FluentMySQL/MySQLType.swift
@@ -70,13 +70,13 @@ extension MySQLDataConvertible where Self: RawRepresentable, Self.RawValue: MySQ
 
     /// See `MySQLDataConvertible.convertFromMySQLData(_:)`
     public static func convertFromMySQLData(_ data: MySQLData) throws -> Self {
-        guard let e = try self.init(rawValue: .convertFromMySQLData(data)) else {
+        guard let extractedCase = try self.init(rawValue: .convertFromMySQLData(data)) else {
             throw MySQLError(
                 identifier: "rawValue",
                 reason: "Could not create `\(Self.self)` from: \(data)",
                 source: .capture()
             )
         }
-        return e
+        return extractedCase
     }
 }

--- a/Sources/FluentMySQL/MySQLType.swift
+++ b/Sources/FluentMySQL/MySQLType.swift
@@ -29,3 +29,55 @@ extension MySQLText: MySQLColumnDefinitionStaticRepresentable {
         return .text()
     }
 }
+
+// MARK: Enum
+/// This type-alias makes it easy to declare nested enum types for your `MySQLModel`.
+///
+///     enum PetType: Int, MySQLEnumType {
+///         case cat, dog
+///     }
+///
+/// `MySQLEnumType` can be used easily with any enum that has a `MySQLType` conforming `RawValue`.
+///
+/// You will need to implement custom `ReflectionDecodable` conformance for enums that have non-standard integer
+/// values or enums whose `RawValue` is not an integer.
+///
+///     enum FavoriteTreat: String, MySQLEnumType {
+///         case bone = "b"
+///         case tuna = "t"
+///         static func reflectDecoded() -> (FavoriteTreat, FavoriteTreat) {
+///             return (.bone, .tuna)
+///         }
+///     }
+///
+public protocol MySQLEnumType: MySQLType, ReflectionDecodable, Codable, RawRepresentable where Self.RawValue: MySQLDataConvertible { }
+
+/// Provides a default `MySQLColumnDefinitionStaticRepresentable` implementation where the type is also
+/// `RawRepresentable` by a `MySQLColumnDefinitionStaticRepresentable` type.
+extension MySQLColumnDefinitionStaticRepresentable where Self: RawRepresentable, Self.RawValue: MySQLColumnDefinitionStaticRepresentable
+{
+    public static var mySQLColumnDefinition: MySQLColumnDefinition { return RawValue.mySQLColumnDefinition }
+}
+
+/// Provides a default `MySQLDataConvertible` implementation where the type is also
+/// `RawRepresentable` by a `MySQLDataConvertible` type.
+extension MySQLDataConvertible
+    where Self: RawRepresentable, Self.RawValue: MySQLDataConvertible
+{
+    /// See `MySQLDataConvertible.convertToMySQLData()`
+    public func convertToMySQLData() throws -> MySQLData {
+        return try rawValue.convertToMySQLData()
+    }
+
+    /// See `MySQLDataConvertible.convertFromMySQLData(_:)`
+    public static func convertFromMySQLData(_ data: MySQLData) throws -> Self {
+        guard let e = try self.init(rawValue: .convertFromMySQLData(data)) else {
+            throw MySQLError(
+                identifier: "rawValue",
+                reason: "Could not create `\(Self.self)` from: \(data)",
+                source: .capture()
+            )
+        }
+        return e
+    }
+}

--- a/Sources/FluentMySQL/MySQLType.swift
+++ b/Sources/FluentMySQL/MySQLType.swift
@@ -61,8 +61,7 @@ extension MySQLColumnDefinitionStaticRepresentable where Self: RawRepresentable,
 
 /// Provides a default `MySQLDataConvertible` implementation where the type is also
 /// `RawRepresentable` by a `MySQLDataConvertible` type.
-extension MySQLDataConvertible
-    where Self: RawRepresentable, Self.RawValue: MySQLDataConvertible
+extension MySQLDataConvertible where Self: RawRepresentable, Self.RawValue: MySQLDataConvertible
 {
     /// See `MySQLDataConvertible.convertToMySQLData()`
     public func convertToMySQLData() throws -> MySQLData {


### PR DESCRIPTION
Allow enums to be easily saved and restored from native types,
modeled on implementation from SQLite.