### PR TITLE
add default identifier for the required database

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "3.0.0"),
 
         // 🐬 Pure Swift MySQL client built on non-blocking, event-driven sockets.
-        .package(url: "https://github.com/vapor/mysql.git", .revision("8cf855487d6dc011449cf9c565c295ed24315a75")),
+        .package(url: "https://github.com/vapor/mysql.git", from: "3.0.0"),
     ],
     targets: [
         .target(name: "FluentMySQL", dependencies: ["Async", "FluentSQL", "MySQL"]),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "3.0.0"),
 
         // 🐬 Pure Swift MySQL client built on non-blocking, event-driven sockets.
-        .package(url: "https://github.com/vapor/mysql.git", from: "3.0.0"),
+        .package(url: "https://github.com/gperdomor/mysql.git", .branch("default-identifier")),
     ],
     targets: [
         .target(name: "FluentMySQL", dependencies: ["Async", "FluentSQL", "MySQL"]),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "3.0.0"),
 
         // 🐬 Pure Swift MySQL client built on non-blocking, event-driven sockets.
-        .package(url: "https://github.com/gperdomor/mysql.git", .branch("default-identifier")),
+        .package(url: "https://github.com/vapor/mysql.git", .revision("994f0ac0d4c0eaa2d9a3edf6d44264fcc8d641b0")),
     ],
     targets: [
         .target(name: "FluentMySQL", dependencies: ["Async", "FluentSQL", "MySQL"]),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "3.0.0"),
 
         // 🐬 Pure Swift MySQL client built on non-blocking, event-driven sockets.
-        .package(url: "https://github.com/vapor/mysql.git", .revision("994f0ac0d4c0eaa2d9a3edf6d44264fcc8d641b0")),
+        .package(url: "https://github.com/vapor/mysql.git", .revision("8cf855487d6dc011449cf9c565c295ed24315a75")),
     ],
     targets: [
         .target(name: "FluentMySQL", dependencies: ["Async", "FluentSQL", "MySQL"]),

--- a/Sources/FluentMySQL/FluentMySQLProvider.swift
+++ b/Sources/FluentMySQL/FluentMySQLProvider.swift
@@ -3,16 +3,22 @@ import Service
 
 /// Registers and boots MySQL services.
 public final class FluentMySQLProvider: Provider {
+    let identifier: DatabaseIdentifier<MySQLDatabase>
+    
     /// See Provider.repositoryName
     public static let repositoryName = "fluent-mysql"
 
     /// Create a new `MySQLProvider`
-    public init() {}
+    ///
+    /// - Parameter identifier: the default identifier for the required Database
+    public init(default identifier: DatabaseIdentifier<MySQLDatabase> = .mysql) {
+        self.identifier = identifier
+    }
     
     /// See Provider.register
     public func register(_ services: inout Services) throws {
         try services.register(FluentProvider())
-        try services.register(MySQLProvider())
+        try services.register(MySQLProvider(default: self.identifier))
     }
     
     /// See Provider.boot


### PR DESCRIPTION
This PR prevent this error...
```
Fatal error: Error raised at top level: ⚠️ DatabaseKit Error: No database with id 'mysql' is configured.
- id: DatabaseKitError.dbRequired
```

... when you register one or more databases with custom identifiers but none is .mysql

Depends on: https://github.com/vapor/mysql/pull/202
