### PR TITLE
MySQLDatabase support for deleteColumns

### DIFF
--- a/Sources/FluentMySQL/MySQLDatabase+SchemaSupporting.swift
+++ b/Sources/FluentMySQL/MySQLDatabase+SchemaSupporting.swift
@@ -73,6 +73,7 @@ extension MySQLDatabase: SchemaSupporting {
         case ._alterTable:
             var alterTable: MySQLAlterTable = .alterTable(fluent.table)
             alterTable.columns = fluent.columns
+            alterTable.deleteColumns = fluent.deleteColumns
             alterTable.constraints = fluent.constraints
             alterTable.columnPositions = fluent.columnPositions
             query = ._alterTable(alterTable)

--- a/Tests/FluentMySQLTests/FluentMySQLMigrationTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLMigrationTests.swift
@@ -1,0 +1,65 @@
+import FluentBenchmark
+import FluentMySQL
+import Fluent
+import XCTest
+
+class FluentMySQLMigrationTests: XCTestCase {
+    var benchmarker: Benchmarker<MySQLDatabase>!
+    var database: MySQLDatabase!
+    
+    override func setUp() {
+        let eventLoop = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let config = MySQLDatabaseConfig(
+            hostname: "localhost",
+            port: 3306,
+            username: "vapor_username",
+            password: "vapor_password",
+            database: "vapor_database",
+            transport: .cleartext
+        )
+        database = MySQLDatabase(config: config)
+        benchmarker = try! Benchmarker(database, on: eventLoop, onFail: XCTFail)
+    }
+    
+    func testMySQLDeleteColumns() throws {
+        let conn = try benchmarker.pool.requestConnection().wait()
+        defer { _ = try? Parent.revert(on: conn).wait() }
+        
+        let dropResults = try conn.simpleQuery("DROP TABLE IF EXISTS \(Parent.entity);").wait()
+        XCTAssertEqual(dropResults.count, 0)
+        
+        _ = try Parent.prepare(on: conn).wait()
+        _ = try Parent(id: nil, name: "A").save(on: conn).wait()
+
+        let preSelectResults = try conn.raw("SELECT * FROM \(Parent.entity);").all().wait()
+        XCTAssertEqual(preSelectResults.count, 1)
+        XCTAssertEqual(preSelectResults[0].count, 2) // 2 columns
+        
+        struct DropParentName: Migration {
+            static let migrationName = "drop_parent_name"
+            
+            typealias Database = MySQLDatabase
+            
+            static func prepare(on connection: MySQLConnection) -> Future<Void> {
+                return MySQLDatabase.update(Parent.self, on: connection) { updater in
+                    updater.deleteField(for: \Parent.name)
+                }
+            }
+
+            static func revert(on conn: MySQLConnection) -> EventLoopFuture<Void> {
+                return conn.eventLoop.newSucceededFuture(result: ())
+            }
+        }
+        
+        _ = try DropParentName.prepare(on: conn).wait()
+        
+        let postSelectResults = try conn.raw("SELECT * FROM \(Parent.entity);").all().wait()
+        XCTAssertEqual(postSelectResults.count, 1)
+        XCTAssertEqual(postSelectResults[0].count, 1) // 1 columns
+        XCTAssertEqual(postSelectResults[0].keys.first!, MySQLColumn(table: Parent.entity, name: "id"))
+    }
+    
+    static let allTests = [
+        ("testMySQLDeleteColumns", testMySQLDeleteColumns),
+    ]
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,7 +4,8 @@ import XCTest
 @testable import FluentMySQLTests
 
 XCTMain([
-    testCase(FluentMySQLTests.allTests)
+    testCase(FluentMySQLTests.allTests),
+    testCase(FluentMySQLMigrationTests.allTests),
 ])
 
 #endif


### PR DESCRIPTION
Added deleteColumns to MySQLDatabase

This change allows columns to be deleted (DROP).

**Please note:** These changes are built on extended functionality in MySQLDatabase:SchemaSupporting and I was not sure how to update the Package.swift file to bind to a yet-unreleased version of vapor/mysql.  Thus, the tests **will fail** until this binding is updated.