### PR TITLE
Added Optional Parent Tests From FluentBenchmarker

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0-alpha.2"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("optional-parent")),
         .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
+++ b/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
@@ -41,6 +41,18 @@ final class FluentMySQLDriverTests: XCTestCase {
         try self.benchmarker.testEagerLoadParentJSON()
     }
 
+    func testEagerLoadOptionalParent() throws {
+        try self.benchmarker.testEagerLoadOptionalParent()
+    }
+
+    func testEagerLoadOptionalJoinParent() throws {
+        try self.benchmarker.testEagerLoadOptionalJoinParent()
+    }
+    
+    func testEagerLoadOptionalChildren() throws {
+        try self.benchmarker.testEagerLoadOptionalChildren()
+    }
+
     func testEagerLoadChildrenJSON() throws {
         try self.benchmarker.testEagerLoadChildrenJSON()
     }


### PR DESCRIPTION
Relies on https://github.com/vapor/fluent-kit/pull/63. Make sure to update the package manifest for this repo after merging the FluentKit PR and before merging this one.