### PR TITLE
Fixes `createdAt` / `updatedAt` for upserts

### DIFF
--- a/Sources/FluentMySQL/Fluent+MySQLUpsert.swift
+++ b/Sources/FluentMySQL/Fluent+MySQLUpsert.swift
@@ -15,12 +15,14 @@ extension QueryBuilder where Result: Model, Result.Database == Database, Result.
                     copy.fluentUpdatedAt = Date()
                 }
             }
+            let createdAtRowIdentifier = (try? Result.reflectProperty(forKey: \.fluentCreatedAt)?.path.first) ?? nil
 
             let row = SQLQueryEncoder(MySQLExpression.self).encode(copy)
             let values = row.compactMap { row -> (MySQLIdentifier, MySQLExpression)? in
                 let identifier: MySQLIdentifier = .identifier(row.key)
+
                 // We don't want to delete `createdAt` for entries that got upserted
-                if Result.createdAtKey != nil && copy.fluentCreatedAt == nil && identifier.string == "createdAt" {
+                if Result.createdAtKey != nil && copy.fluentCreatedAt == nil && identifier.string == createdAtRowIdentifier {
                     return nil
                 }
                 return (identifier, row.value)

--- a/Tests/FluentMySQLTests/FluentMySQLTests.swift
+++ b/Tests/FluentMySQLTests/FluentMySQLTests.swift
@@ -12,8 +12,8 @@ class FluentMySQLTests: XCTestCase {
         let config = MySQLDatabaseConfig(
             hostname: "localhost",
             port: 3306,
-            username: "root",
-            password: "root",
+            username: "vapor_username",
+            password: "vapor_password",
             database: "vapor_database",
             transport: .cleartext
         )


### PR DESCRIPTION
Fixes #152 

Fixes an issue with upserts, where `createdAt` and `updatedAt` are not updated properly but set to `NULL` instead.

- [x] Fixes the issue
- [x] Added two test assertions
- [x] Need some support with line 23 in `Sources/FluentMySQL/Fluent+MySQLUpsert.swift`: how can I check for the actual name of the property set via Keypath (`createdAtKey`)? https://github.com/vapor/fluent-mysql-driver/pull/153/files#r349925550

