### PR TITLE
Redo CI to test mysql 5.7, 8.0, and mariadb on macOS and Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
   fluent-mysql-driver_ubuntu:
     strategy:
       matrix:
-        os: [xenial, bionic]
-        image: [mysql:8.0, mysql:5.7, mariadb:latest]
+        os: ['xenial', 'bionic']
+        image: ['mysql:8.0', 'mysql:5.7', 'mariadb:latest']
     container: 
       image: vapor/swift:5.2-${{ matrix.os }}-ci
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
     - run: brew services start ${{ matrix.formula }}
     - run: sleep 4 # give the server a chance to settle
     - run: mysqladmin -u${{ matrix.username }} create vapor_database
-    - run: mysql -u${{ matrix.username }} --batch <<<"CREATE USER vapor_username IDENTIFIED BY 'vapor_password';"
-    - run: mysql -u${{ matrix.username }} --batch <<<"GRANT ALL PRIVILEGES ON vapor_database.* TO vapor_username;"
+    - run: mysql -u${{ matrix.username }} --batch <<<"CREATE USER vapor_username@localhost IDENTIFIED BY 'vapor_password';"
+    - run: mysql -u${{ matrix.username }} --batch <<<"GRANT ALL PRIVILEGES ON vapor_database.* TO vapor_username@localhost;"
     - uses: actions/checkout@v2
     - run: xcrun swift test --enable-test-discovery --sanitize=thread
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
 jobs:
   fluent-mysql-driver_macos:
     strategy:
+      fail-fast: false
       matrix:
         formula: ['mysql', 'mysql@5.7', 'mariadb']
         include:
@@ -28,6 +29,7 @@ jobs:
     - run: brew services stop ${{ matrix.formula }}
   fluent-mysql-driver_ubuntu:
     strategy:
+      fail-fast: false
       matrix:
         os: ['xenial', 'bionic']
         image: ['mysql:8.0', 'mysql:5.7', 'mariadb:latest']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
     - run: mysql -u${{ matrix.username }} --batch <<<"GRANT ALL PRIVILEGES ON vapor_database.* TO vapor_username;"
     - uses: actions/checkout@v2
     - run: xcrun swift test --enable-test-discovery --sanitize=thread
+      env:
+        MYSQL_HOSTNAME: '127.0.0.1'
     - run: brew services stop ${{ matrix.formula }}
   fluent-mysql-driver_ubuntu:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,17 @@ jobs:
   fluent-mysql-driver_macos:
     strategy:
       matrix:
-        formula: [mysql, mysql@5.7, mariadb]
+        formula: ['mysql', 'mysql@5.7', 'mariadb']
         include:
           - username: root
-          - formula: mariadb
+          - formula: 'mariadb'
             username: runner
     runs-on: macos-latest
     steps:
     - run: sudo xcode-select -s /Applications/Xcode_11.4.app/Contents/Developer
     - run: brew install ${{ matrix.formula }}
     - run: brew link --force ${{ matrix.formula }}
-      if: matrix.formula == mysql@5.7
+      if: matrix.formula == 'mysql@5.7'
     - run: brew services start ${{ matrix.formula }}
     - run: sleep 4 # give the server a chance to settle
     - run: mysqladmin -u${{ matrix.username }} create vapor_database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,38 @@ name: test
 on:
 - pull_request
 jobs:
-  fluent-mysql-driver-8_0:
+  fluent-mysql-driver_macos:
+    strategy:
+      matrix:
+        formula: [mysql, mysql@5.7, mariadb]
+        include:
+          - username: root
+          - formula: mariadb
+            username: runner
+    runs-on: macos-latest
+    steps:
+    - run: sudo xcode-select -s /Applications/Xcode_11.4.app/Contents/Developer
+    - run: brew install ${{ matrix.formula }}
+    - run: brew link --force ${{ matrix.formula }}
+      if: matrix.formula == mysql@5.7
+    - run: brew services start ${{ matrix.formula }}
+    - run: sleep 4 # give the server a chance to settle
+    - run: mysqladmin -u${{ matrix.username }} create vapor_database
+    - run: mysql -u${{ matrix.username }} --batch <<<"CREATE USER vapor_username IDENTIFIED BY 'vapor_password';"
+    - run: mysql -u${{ matrix.username }} --batch <<<"GRANT ALL PRIVILEGES ON vapor_database.* TO vapor_username;"
+    - uses: actions/checkout@v2
+    - run: xcrun swift test --enable-test-discovery --sanitize=thread
+    - run: brew services stop ${{ matrix.formula }}
+  fluent-mysql-driver_ubuntu:
+    strategy:
+      matrix:
+        os: [xenial, bionic]
+        image: [mysql:8.0, mysql:5.7, mariadb:latest]
     container: 
-      image: vapor/swift:5.2
+      image: vapor/swift:5.2-${{ matrix.os }}-ci
     services:
       mysql:
-        image: mysql:8.0
+        image: ${{ matrix.image }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: vapor_database
@@ -15,24 +41,7 @@ jobs:
           MYSQL_PASSWORD: vapor_password
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --sanitize=thread
-      env:
-        MYSQL_HOSTNAME: mysql
-  fluent-mysql-driver-5_7:
-    container: 
-      image: vapor/swift:5.2
-    services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: vapor_database
-          MYSQL_USER: vapor_username
-          MYSQL_PASSWORD: vapor_password
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: swift test --enable-test-discovery --sanitize=thread
       env:
         MYSQL_HOSTNAME: mysql


### PR DESCRIPTION
Leverage the `matrix` strategy feature of GitHub workflows to generate 9 different tests:
- mysql 8.0 on xenial, bionic, macos
- mysql 5.7 on xenial, bionic, macos
- mariadb latest on xenial, bionic, macos

Uses Homebrew to get a local MySQL server on macOS.