### PR TITLE
Date and Bool fixes

### DIFF
--- a/Sources/FluentMySQLDriver/MySQLConverterDelegate.swift
+++ b/Sources/FluentMySQLDriver/MySQLConverterDelegate.swift
@@ -6,7 +6,7 @@ struct MySQLConverterDelegate: SQLConverterDelegate {
         case .string: return SQLRaw("VARCHAR(255)")
         case .datetime: return SQLRaw("DATETIME(6)")
         case .uuid: return SQLRaw("VARBINARY(16)")
-        case .bool: return SQLRaw("BIT")
+        case .bool: return SQLRaw("BOOL")
         case .array: return SQLRaw("JSON")
         default: return nil
         }

--- a/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
+++ b/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
@@ -205,8 +205,8 @@ final class FluentMySQLDriverTests: XCTestCase {
         try falseValue.save(on: self.db).wait()
 
         XCTAssertEqual(try Clarity.query(on: self.db).count().wait(), 2)
-        XCTAssertEqual(try Clarity.query(on: self.db).filter(\.$rain == true).count().wait(), 1)
-        XCTAssertEqual(try Clarity.query(on: self.db).filter(\.$rain == false).count().wait(), 1)
+        XCTAssertEqual(try Clarity.query(on: self.db).filter(\.$rain == true).first().wait()?.id, trueValue.id)
+        XCTAssertEqual(try Clarity.query(on: self.db).filter(\.$rain == false).first().wait()?.id, falseValue.id)
     }
 
     func testDateDecoding() throws {

--- a/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
+++ b/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
@@ -204,9 +204,15 @@ final class FluentMySQLDriverTests: XCTestCase {
         try trueValue.save(on: self.db).wait()
         try falseValue.save(on: self.db).wait()
 
-        XCTAssertEqual(try Clarity.query(on: self.db).count().wait(), 2)
-        XCTAssertEqual(try Clarity.query(on: self.db).filter(\.$rain == true).first().wait()?.id, trueValue.id)
-        XCTAssertEqual(try Clarity.query(on: self.db).filter(\.$rain == false).first().wait()?.id, falseValue.id)
+        try XCTAssertEqual(Clarity.query(on: self.db).count().wait(), 2)
+        try XCTAssertEqual(
+            Clarity.query(on: self.db).filter(\.$rain == true).first().wait()?.id,
+            trueValue.id
+        )
+        try  XCTAssertEqual(
+            Clarity.query(on: self.db).filter(\.$rain == false).first().wait()?.id,
+            falseValue.id
+        )
     }
 
     func testDateDecoding() throws {
@@ -242,8 +248,12 @@ final class FluentMySQLDriverTests: XCTestCase {
         defer { try? CreateClarity().revert(on: self.db).wait() }
         try CreateClarity().prepare(on: self.db).wait()
 
-        let firstDate = Date()
-        let secondDate = Date(timeIntervalSinceNow: 100.0)
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)!
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        let firstDate = formatter.date(from: "2020-01-01")!
+        let secondDate = formatter.date(from: "1994-05-23")!
         let trueValue = Clarity(date: firstDate)
         let falseValue = Clarity(date: secondDate)
 


### PR DESCRIPTION
Fixes some regressions around `Date` and `Bool` handling (#168).

- `Foundation.Date` can now be decoded from `.date` (`DATE`) columns.
> Note: Time information will be silently discarded when `Foundation.Date` is stored in `.date` column. Use `.datetime` (`DATETIME(6)`) to store date + time. 
- Fluent's `.bool` data type and `Swift.Bool` now use MySQL's `BOOL` (`TINYINT`) column type instead of `BIT`. 