### PR TITLE
Add custom JSON encoder / decoder support 

### DIFF
--- a/Sources/FluentMySQLDriver/Exports.swift
+++ b/Sources/FluentMySQLDriver/Exports.swift
@@ -4,6 +4,8 @@
 
 @_exported import struct MySQLKit.MySQLConfiguration
 @_exported import struct MySQLKit.MySQLConnectionSource
+@_exported import struct MySQLKit.MySQLDataEncoder
+@_exported import struct MySQLKit.MySQLDataDecoder
 
 @_exported import class MySQLNIO.MySQLConnection
 @_exported import enum MySQLNIO.MySQLError

--- a/Sources/FluentMySQLDriver/FluentMySQLDriver.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLDriver.swift
@@ -2,6 +2,8 @@ import AsyncKit
 
 struct _FluentMySQLDriver: DatabaseDriver {
     let pool: EventLoopGroupConnectionPool<MySQLConnectionSource>
+    let encoder: MySQLDataEncoder
+    let decoder: MySQLDataDecoder
     
     var eventLoopGroup: EventLoopGroup {
         self.pool.eventLoopGroup
@@ -10,6 +12,8 @@ struct _FluentMySQLDriver: DatabaseDriver {
     func makeDatabase(with context: DatabaseContext) -> Database {
         _FluentMySQLDatabase(
             database: self.pool.pool(for: context.eventLoop).database(logger: context.logger),
+            encoder: self.encoder,
+            decoder: self.decoder,
             context: context,
             inTransaction: false
         )

--- a/Sources/FluentMySQLDriver/MySQLRow+Database.swift
+++ b/Sources/FluentMySQLDriver/MySQLRow+Database.swift
@@ -1,11 +1,12 @@
 extension MySQLRow {
-    internal func databaseOutput() -> DatabaseOutput {
-        _MySQLDatabaseOutput(row: self, schema: nil)
+    internal func databaseOutput(decoder: MySQLDataDecoder) -> DatabaseOutput {
+        _MySQLDatabaseOutput(row: self, decoder: decoder, schema: nil)
     }
 }
 
 private struct _MySQLDatabaseOutput: DatabaseOutput {
     let row: MySQLRow
+    let decoder: MySQLDataDecoder
     let schema: String?
 
     var description: String {
@@ -27,6 +28,7 @@ private struct _MySQLDatabaseOutput: DatabaseOutput {
     func schema(_ schema: String) -> DatabaseOutput {
         _MySQLDatabaseOutput(
             row: self.row,
+            decoder: self.decoder,
             schema: schema
         )
     }
@@ -34,7 +36,9 @@ private struct _MySQLDatabaseOutput: DatabaseOutput {
     func decode<T>(_ key: FieldKey, as type: T.Type) throws -> T
         where T: Decodable
     {
-        try self.row.decode(column: self.columnName(key), as: T.self)
+        try self.row
+            .sql(decoder: self.decoder)
+            .decode(column: self.columnName(key), as: T.self)
     }
 
 


### PR DESCRIPTION
Adds support for configuring which JSON coders MySQL uses when serializing nested data to the database (#189).

```swift
// Setup custom JSON coders that use unix timestamps
let encoder = JSONEncoder()
encoder.dateEncodingStrategy = .secondsSince1970
let decoder = JSONDecoder()
decoder.dateDecodingStrategy = .secondsSince1970

// Configure MySQL database.
app.databaes.use(.mysql(
    configuration: ..., 
    encoder: MySQLDataEncoder(json: encoder), 
    decoder: MySQLDataDecoder(json: decoder)
))
```

Note that for dates specifically, you can use [`@Timestamp` formats](https://docs.vapor.codes/4.0/fluent/model/#timestamp-format) to configure formatting per field. 