### PR TITLE
Fix .references field constraint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("tn-field-references")),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.6.0"),
         .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.0.0-rc.1.2"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("tn-field-references")),
+        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Adds a fix for a MySQL [syntax quirk](https://stackoverflow.com/questions/14672872/difference-between-references-and-foreign-key) that caused `.references` constraints to be ignored (#191, fixes #170).

MySQL does not allow the `REFERENCES foreign_table (column_name)` syntax like Fluent's other drivers do. When it sees this syntax, it simply ignores it with no warning. The only supported method for declaring for keys is to declare them as "table level" constraints. In other words, as a separate item in the create list. 

This change causes MySQL's `SQLSchemaConverter` to automatically translate field-level foreign key constraints (`.references`) to their table-level counterparts. 