### PR TITLE
Make LastInsertIDInitializable public

### DIFF
--- a/Sources/FluentMySQLDriver/FluentMySQLDatabase.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLDatabase.swift
@@ -154,12 +154,12 @@ private struct LastInsertRow: DatabaseOutput {
     }
 }
 
-protocol LastInsertIDInitializable {
+public protocol LastInsertIDInitializable {
     init(lastInsertID: UInt64)
 }
 
 extension LastInsertIDInitializable where Self: FixedWidthInteger {
-    init(lastInsertID: UInt64) {
+    public init(lastInsertID: UInt64) {
         self = numericCast(lastInsertID)
     }
 }


### PR DESCRIPTION
Make `LastInsertIDInitializable` `public`.
The `IDValue` of `Model` that generated by database must conform to `LastInsertIDInitializable`.
This change lets any type to conform to it.