### PR TITLE
Improved error reporting via `DatabaseError`

### DIFF
--- a/Sources/FluentMySQLDriver/MySQLError+Database.swift
+++ b/Sources/FluentMySQLDriver/MySQLError+Database.swift
@@ -1,19 +1,28 @@
 extension MySQLError: DatabaseError {
     public var isSyntaxError: Bool {
-        return false
+        switch self {
+            case .invalidSyntax(_):
+                return true
+            default:
+                return false
+        }
     }
 
     public var isConstraintFailure: Bool {
         switch self {
             case .duplicateEntry(_):
                 return true
-            
             default:
                 return false
         }
     }
 
     public var isConnectionClosed: Bool {
-        return false
+        switch self {
+            case .closed:
+                return true
+            default:
+                return false
+        }
     }
 }


### PR DESCRIPTION
`DatabaseError`'s `isSyntaxError` and `isConnectionClosed` properties now correctly respect `MySQLError.invalidSyntax` and `MySQLError.closed` errors. A unit tests for these behaviors is included.

Also avoids double-running the FluentBenchmark tests (same change as [fluent-sqlite-driver#75](https://github.com/vapor/fluent-sqlite-driver/pull/75)).
