### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Run tests with Thread Sanitizer
-        run: swift test --sanitize=thread
+        run: swift test
         env: 
           LOG_LEVEL: info
           MYSQL_HOSTNAME_A: '127.0.0.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,42 +12,13 @@ jobs:
         dbimage:
           - mysql:5.7
           - mysql:8.0
-          - mariadb:latest
+          - mariadb:10.3
+          - mariadb:10.7
+          - percona:8.0
         runner:
-          - swift:5.2-xenial
-          - swift:5.2-bionic
-          - swift:5.2-focal
-          - swift:5.2-centos7
-          - swift:5.2-centos8
-          - swift:5.2-amazonlinux2
-          - swift:5.3-xenial
-          - swift:5.3-bionic
-          - swift:5.3-focal
-          - swift:5.3-centos7
-          - swift:5.3-centos8
-          - swift:5.3-amazonlinux2
-          - swift:5.4-bionic
-          - swift:5.4-focal
-          - swift:5.4-centos7
-          - swift:5.4-centos8
-          - swift:5.4-amazonlinux2
-          - swiftlang/swift:nightly-5.5-focal
-          - swiftlang/swift:nightly-5.5-centos8
-          - swiftlang/swift:nightly-5.5-amazonlinux2
+          - swift:5.5-focal
+          - swift:5.6-focal
           - swiftlang/swift:nightly-main-focal
-          - swiftlang/swift:nightly-main-centos8
-          - swiftlang/swift:nightly-main-amazonlinux2
-        exclude:
-          - runner: swift:5.2-amazonlinux2
-            dbimage: mysql:8.0
-          - runner: swift:5.3-amazonlinux2
-            dbimage: mysql:8.0
-          - runner: swift:5.4-amazonlinux2
-            dbimage: mysql:8.0
-          - runner: swiftlang/swift:nightly-5.5-amazonlinux2
-            dbimage: mysql:8.0
-          - runner: swiftlang/swift:nightly-main-amazonlinux2
-            dbimage: mysql:8.0
     container: ${{ matrix.runner }}
     runs-on: ubuntu-latest
     services:
@@ -66,36 +37,34 @@ jobs:
           MYSQL_PASSWORD: vapor_password
           MYSQL_DATABASE: vapor_database
     steps:
-      - name: Workaround SPM incompatibility with old Git on CentOS 7
-        if: ${{ contains(matrix.runner, 'centos7') }}
-        run: |
-          yum install -y make libcurl-devel
-          git clone https://github.com/git/git -bv2.28.0 --depth 1 && cd git
-          make prefix=/usr -j all install NO_OPENSSL=1 NO_EXPAT=1 NO_TCLTK=1 NO_GETTEXT=1 NO_PERL=1
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --sanitize=thread
         env:
           LOG_LEVEL: info
           MYSQL_HOSTNAME_A: mysql-a
           MYSQL_HOSTNAME_B: mysql-b
-  macOS:
+  macos:
     strategy:
       fail-fast: false
       matrix:
         formula: 
-          - mysql@8.0
+          - mysql
           - mysql@5.7
           - mariadb
+          - percona-server
         xcode:
           - latest
           - latest-stable
+        macos:
+          - macos-11
+          - macos-12
         include:
           - username: root
           - formula: mariadb
             username: runner
-    runs-on: macos-latest
+    runs-on: ${{ matrix.macos }}
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -116,9 +85,9 @@ jobs:
               CREATE DATABASE vapor_database_b; GRANT ALL PRIVILEGES ON vapor_database_b.* TO vapor_username@localhost;
           SQL
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --sanitize=thread
         env: 
           LOG_LEVEL: info
           MYSQL_HOSTNAME_A: '127.0.0.1'


### PR DESCRIPTION
Same updates as https://github.com/vapor/mysql-nio/pull/77, and wow are they needed here:

- MariaDB 10.2 is EOL in 5 days at the time of this writing, bump minimum version to 10.3
- Ditch Percona 5.7, we don't really care about it
- Ditch Swift 5.2/5.3/5.4 testing, test Swift 5.6
- Use v3 checkout action
- Test on macOS Monterey, now that GH actions supports it

(oh and ditch a whole heck of a lot of old things)