### PR TITLE
Explicitly handle a custom ID key set to the empty string

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.24.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("composite-primary-key-models")),
         .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("composite-primary-key-models")),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.27.0"),
         .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Sources/FluentMySQLDriver/FluentMySQLDatabase.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLDatabase.swift
@@ -26,7 +26,7 @@ extension _FluentMySQLDatabase: Database {
                 },
                 onMetadata: { metadata in
                     switch query.action {
-                    case .create:
+                    case .create where query.customIDKey != .string(""):
                         let row = LastInsertRow(
                             metadata: metadata,
                             customIDKey: query.customIDKey

--- a/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
+++ b/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
@@ -13,6 +13,7 @@ final class FluentMySQLDriverTests: XCTestCase {
     func testChildren() throws { try self.benchmarker.testChildren() }
     func testCodable() throws { try self.benchmarker.testCodable() }
     func testChunk() throws { try self.benchmarker.testChunk() }
+    func testCompositeID() throws { try self.benchmarker.testCompositeID() }
     func testCRUD() throws { try self.benchmarker.testCRUD() }
     func testEagerLoad() throws { try self.benchmarker.testEagerLoad() }
     func testEnum() throws { try self.benchmarker.testEnum() }


### PR DESCRIPTION
Treat it as meaning not to retrieve an inserted ID value. This is in support of upcoming FluentKit feature work.