### PR TITLE
Drop support for Swift 5.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,84 @@
 name: test
-on: 
-  - pull_request
-defaults:
-  run:
-    shell: bash
+on:
+  pull_request: { branches: ['*'] }
+  push: { branches: [ main ] }
+
+env:
+  LOG_LEVEL: debug
+  SWIFT_DETERMINISTIC_HASHING: 1
+  MYSQL_HOSTNAME: 'mysql-a'
+  MYSQL_HOSTNAME_A: 'mysql-a'
+  MYSQL_HOSTNAME_B: 'mysql-b'
+  MYSQL_DATABASE: 'test_database'
+  MYSQL_DATABASE_A: 'test_database'
+  MYSQL_DATABASE_B: 'test_database'
+  MYSQL_USERNAME: 'test_username'
+  MYSQL_USERNAME_A: 'test_username'
+  MYSQL_USERNAME_B: 'test_username'
+  MYSQL_PASSWORD: 'test_password'
+  MYSQL_PASSWORD_A: 'test_password'
+  MYSQL_PASSWORD_B: 'test_password'
+
 jobs:
-  linux:
+
+  codecov:
+    strategy:
+      # For MySQL we have to run coverage baselines against multiple DB versions thanks to
+      # the driver's behavior changing notably depending on the server.
+      matrix: { dbimage: ['mysql:5.7', 'mysql:8.0', 'mariadb:10.7'] }
+    runs-on: ubuntu-latest
+    container: swift:5.7-jammy
+    services:
+      mysql-a:
+        image: ${{ matrix.dbimage }}
+        env: 
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_USER: test_username
+          MYSQL_PASSWORD: test_password
+          MYSQL_DATABASE: test_database
+      mysql-b:
+        image: ${{ matrix.dbimage }}
+        env: 
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_USER: test_username
+          MYSQL_PASSWORD: test_password
+          MYSQL_DATABASE: test_database
+    steps:
+      - name: Save MySQL version to env
+        run: |
+          echo MYSQL_VERSION='${{ matrix.dbimage }}' >> $GITHUB_ENV
+      - name: Check out package
+        uses: actions/checkout@v3
+      - name: Run local tests with coverage
+        run: swift test --enable-code-coverage
+      - name: Submit coverage report to Codecov.io
+        uses: vapor/swift-codecov-action@v0.2
+        with:
+          cc_flags: 'unittests'
+          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,MYSQL_VERSION'
+          cc_fail_ci_if_error: true
+          cc_verbose: true
+          cc_dry_run: false
+
+  # Check for API breakage versus main
+  api-breakage:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    container: swift:5.7-jammy
+    steps:
+      - name: Check out package
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the workspace as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Check for API breaking changes
+        run: swift package diagnose-api-breaking-changes origin/main
+
+  # Unit tests (Linux)
+  linux-unit:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -16,54 +89,46 @@ jobs:
           - mariadb:10.7
           - percona:8.0
         runner:
-          - swift:5.5-focal
+          - swift:5.5-bionic
           - swift:5.6-focal
-          - swiftlang/swift:nightly-main-focal
-    container: ${{ matrix.runner }}
+          - swift:5.7-jammy
+          - swiftlang/swift:nightly-main-jammy
     runs-on: ubuntu-latest
+    container: ${{ matrix.runner }}
     services:
       mysql-a:
         image: ${{ matrix.dbimage }}
         env: 
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-          MYSQL_USER: vapor_username
-          MYSQL_PASSWORD: vapor_password
-          MYSQL_DATABASE: vapor_database
+          MYSQL_USER: test_username
+          MYSQL_PASSWORD: test_password
+          MYSQL_DATABASE: test_database
       mysql-b:
         image: ${{ matrix.dbimage }}
         env: 
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-          MYSQL_USER: vapor_username
-          MYSQL_PASSWORD: vapor_password
-          MYSQL_DATABASE: vapor_database
+          MYSQL_USER: test_username
+          MYSQL_PASSWORD: test_password
+          MYSQL_DATABASE: test_database
     steps:
-      - name: Check out code
+      - name: Check out package
         uses: actions/checkout@v3
       - name: Run tests with Thread Sanitizer
         run: swift test --sanitize=thread
-        env:
-          LOG_LEVEL: info
-          MYSQL_HOSTNAME_A: mysql-a
-          MYSQL_HOSTNAME_B: mysql-b
-  macos:
+
+  # Unit tests (macOS)
+  macos-unit:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
-        formula: 
-          - mysql
-          - mysql@5.7
-          - mariadb
-          - percona-server
-        xcode:
-          - latest
-          - latest-stable
+        formula:
+          - mysql@8.0
         macos:
           - macos-11
           - macos-12
-        include:
-          - username: root
-          - formula: mariadb
-            username: runner
+        xcode:
+          - latest-stable
     runs-on: ${{ matrix.macos }}
     steps:
       - name: Select latest available Xcode
@@ -75,22 +140,21 @@ jobs:
       - name: Start MySQL server
         run: brew services start ${{ matrix.formula }}
       - name: Wait for MySQL server to be ready
-        run: until echo | mysql -u${{ matrix.username }}; do sleep 1; done
+        run: until echo | mysql -uroot; do sleep 1; done
         timeout-minutes: 5
       - name: Set up MySQL databases and privileges
         run: |
-          mysql -u${{ matrix.username }} --batch <<-'SQL'
-              CREATE USER vapor_username@localhost IDENTIFIED BY 'vapor_password';
-              CREATE DATABASE vapor_database_a; GRANT ALL PRIVILEGES ON vapor_database_a.* TO vapor_username@localhost;
-              CREATE DATABASE vapor_database_b; GRANT ALL PRIVILEGES ON vapor_database_b.* TO vapor_username@localhost;
+          mysql -uroot --batch <<-'SQL'
+              CREATE USER test_username@localhost IDENTIFIED BY 'test_password';
+              CREATE DATABASE test_database_a; GRANT ALL PRIVILEGES ON test_database_a.* TO test_username@localhost;
+              CREATE DATABASE test_database_b; GRANT ALL PRIVILEGES ON test_database_b.* TO test_username@localhost;
           SQL
       - name: Check out code
         uses: actions/checkout@v3
       - name: Run tests with Thread Sanitizer
-        run: swift test
+        run: swift test --sanitize=thread
         env: 
-          LOG_LEVEL: info
           MYSQL_HOSTNAME_A: '127.0.0.1'
           MYSQL_HOSTNAME_B: '127.0.0.1'
-          MYSQL_DATABASE_A: vapor_database_a
-          MYSQL_DATABASE_B: vapor_database_b
+          MYSQL_DATABASE_A: test_database_a
+          MYSQL_DATABASE_B: test_database_b

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(

--- a/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
+++ b/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
@@ -370,13 +370,13 @@ final class FluentMySQLDriverTests: XCTestCase {
 
         var tls = TLSConfiguration.makeClientConfiguration()
         tls.certificateVerification = .none
-        let databaseA = env("MYSQL_DATABASE_A") ?? "vapor_database"
-        let databaseB = env("MYSQL_DATABASE_B") ?? "vapor_database"
+        let databaseA = env("MYSQL_DATABASE_A") ?? "test_database"
+        let databaseB = env("MYSQL_DATABASE_B") ?? "test_database"
         self.dbs.use(.mysql(
             hostname: env("MYSQL_HOSTNAME_A") ?? "localhost",
             port: env("MYSQL_PORT_A").flatMap(Int.init) ?? 3306,
-            username: env("MYSQL_USERNAME_A") ?? "vapor_username",
-            password: env("MYSQL_PASSWORD_A") ?? "vapor_password",
+            username: env("MYSQL_USERNAME_A") ?? "test_username",
+            password: env("MYSQL_PASSWORD_A") ?? "test_password",
             database: databaseA,
             tlsConfiguration: tls,
             connectionPoolTimeout: .seconds(10)
@@ -385,22 +385,12 @@ final class FluentMySQLDriverTests: XCTestCase {
         self.dbs.use(.mysql(
             hostname: env("MYSQL_HOSTNAME_B") ?? "localhost",
             port: env("MYSQL_PORT_B").flatMap(Int.init) ?? 3306,
-            username: env("MYSQL_USERNAME_B") ?? "vapor_username",
-            password: env("MYSQL_PASSWORD_B") ?? "vapor_password",
+            username: env("MYSQL_USERNAME_B") ?? "test_username",
+            password: env("MYSQL_PASSWORD_B") ?? "test_password",
             database: databaseB,
             tlsConfiguration: tls,
             connectionPoolTimeout: .seconds(10)
         ), as: .b)
-
-        // clear dbs
-        let a = self.dbs.database(.a, logger: Logger(label: "test.fluent.a"), on: self.eventLoopGroup.next())! as! MySQLDatabase
-        _ = try a.simpleQuery("DROP DATABASE \(databaseA)").wait()
-        _ = try a.simpleQuery("CREATE DATABASE \(databaseA)").wait()
-        _ = try a.simpleQuery("USE \(databaseA)").wait()
-        let b = self.dbs.database(.b, logger: Logger(label: "test.fluent.b"), on: self.eventLoopGroup.next())! as! MySQLDatabase
-        _ = try b.simpleQuery("DROP DATABASE \(databaseB)").wait()
-        _ = try b.simpleQuery("CREATE DATABASE \(databaseB)").wait()
-        _ = try b.simpleQuery("USE \(databaseB)").wait()
     }
     
     override func tearDownWithError() throws {


### PR DESCRIPTION
Also incudes a round of CI modernizations.

There are no API or functional changes in this version, but the minimum Swift version bump nonetheless requires this to be a semver-minor release.