### PR TITLE
Shut down the driver's connection pool safely

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.1"),
-        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.7.1"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
+        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.8.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
     ],
     targets: [
@@ -42,6 +42,4 @@ let package = Package(
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
-    .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
 ] }

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.1"),
-        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.7.1"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
+        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.8.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
     ],
     targets: [

--- a/Sources/FluentMySQLDriver/FluentMySQLDriver.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLDriver.swift
@@ -27,6 +27,6 @@ struct _FluentMySQLDriver: DatabaseDriver {
     
     // See `DatabaseDriver.shutdown()`.
     func shutdown() {
-        self.pool.shutdown()
+        try? self.pool.syncShutdownGracefully()
     }
 }


### PR DESCRIPTION
**These changes are now available in [4.5.1](https://github.com/vapor/fluent-mysql-driver/releases/tag/4.5.1)**


Specifically, don't use the soft-deprecated AsyncKit API that calls `EventLoopFuture.wait()` internally; use the one that at least does it with Dispatch (best we can do without changing Fluent's driver interface).

Also updates dependency version requirements.