### PR TITLE
Actually support query logging

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
-        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.8.0"),
+        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
     ],
     targets: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
-        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.8.0"),
+        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
     ],
     targets: [

--- a/Sources/FluentMySQLDriver/Docs.docc/theme-settings.json
+++ b/Sources/FluentMySQLDriver/Docs.docc/theme-settings.json
@@ -12,7 +12,7 @@
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }
     },
-    "icons": { "technology": "/mysqlkit/images/vapor-fluentmysqldriver-logo.svg" }
+    "icons": { "technology": "/fluentmysqldriver/images/vapor-fluentmysqldriver-logo.svg" }
   },
   "features": {
     "quickNavigation": { "enable": true },

--- a/Sources/FluentMySQLDriver/FluentMySQLDriver.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLDriver.swift
@@ -4,7 +4,7 @@ import MySQLKit
 import NIOCore
 
 /// An implementation of `DatabaseDriver` for MySQL .
-struct _FluentMySQLDriver: DatabaseDriver {
+struct FluentMySQLDriver: DatabaseDriver {
     /// The connection pool set for this driver.
     let pool: EventLoopGroupConnectionPool<MySQLConnectionSource>
     
@@ -14,12 +14,16 @@ struct _FluentMySQLDriver: DatabaseDriver {
     /// A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
     let decoder: MySQLDataDecoder
     
+    /// A logging level used for logging queries.
+    let sqlLogLevel: Logger.Level?
+    
     // See `DatabaseDriver.makeDatabase(with:)`.
     func makeDatabase(with context: DatabaseContext) -> any Database {
-        _FluentMySQLDatabase(
+        FluentMySQLDatabase(
             database: self.pool.pool(for: context.eventLoop).database(logger: context.logger),
             encoder: self.encoder,
             decoder: self.decoder,
+            queryLogLevel: self.sqlLogLevel,
             context: context,
             inTransaction: false
         )

--- a/Sources/FluentMySQLDriver/MySQLError+Database.swift
+++ b/Sources/FluentMySQLDriver/MySQLError+Database.swift
@@ -2,7 +2,7 @@ import MySQLNIO
 import FluentKit
 
 /// Conform `MySQLError` to `DatabaseError`.
-extension MySQLError: DatabaseError {
+extension MySQLNIO.MySQLError: FluentKit.DatabaseError {
     // See `DatabaseError.isSyntaxError`.
     public var isSyntaxError: Bool {
         switch self {

--- a/Sources/FluentMySQLDriver/MySQLRow+Database.swift
+++ b/Sources/FluentMySQLDriver/MySQLRow+Database.swift
@@ -2,68 +2,50 @@ import MySQLNIO
 import MySQLKit
 import FluentKit
 
-extension MySQLRow {
+extension SQLRow {
     /// Returns a `DatabaseOutput` for this row.
     /// 
-    /// - Parameter decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values.
     /// - Returns: A `DatabaseOutput` instance.
-    func databaseOutput(decoder: MySQLDataDecoder) -> any DatabaseOutput {
-        _MySQLDatabaseOutput(row: self, decoder: decoder, schema: nil)
+    func databaseOutput() -> any DatabaseOutput {
+        SQLRowDatabaseOutput(row: self, schema: nil)
     }
 }
 
-/// A `DatabaseOutput` implementation for `MySQLRow`s.
-private struct _MySQLDatabaseOutput: DatabaseOutput {
+/// A `DatabaseOutput` implementation for generic `SQLRow`s. This should really be in FluentSQL.
+private struct SQLRowDatabaseOutput: DatabaseOutput {
     /// The underlying row.
-    let row: MySQLRow
-    
-    /// A `MySQLDataDecoder` used to translate `MySQLData` values into output values.
-    let decoder: MySQLDataDecoder
-    
+    let row: any SQLRow
+
     /// The most recently set schema value (see `DatabaseOutput.schema(_:)`).
     let schema: String?
-
-    // See `DatabaseOutput.description`.
+    
+    // See `CustomStringConvertible.description`.
     var description: String {
-        self.row.description
+        String(describing: self.row)
     }
 
-    // See `DatabaseOutput.contains(_:)`.
-    func contains(_ key: FieldKey) -> Bool {
-        self.row.column(self.columnName(key)) != nil
+    /// Apply the current schema (if any) to the given `FieldKey` and convert to a column name.
+    private func adjust(key: FieldKey) -> String {
+        (self.schema.map { .prefix(.prefix(.string($0), "_"), key) } ?? key).description
     }
-
-    // See `DatabaseOutput.decodeNil(_:)`.
-    func decodeNil(_ key: FieldKey) throws -> Bool {
-        if let data = self.row.column((self.columnName(key))) {
-            return data.buffer == nil
-        } else {
-            return true
-        }
-    }
-
+    
     // See `DatabaseOutput.schema(_:)`.
     func schema(_ schema: String) -> any DatabaseOutput {
-        _MySQLDatabaseOutput(
-            row: self.row,
-            decoder: self.decoder,
-            schema: schema
-        )
+        Self(row: self.row, schema: schema)
     }
-
+    
+    // See `DatabaseOutput.contains(_:)`.
+    func contains(_ key: FieldKey) -> Bool {
+        self.row.contains(column: self.adjust(key: key))
+    }
+    
+    // See `DatabaseOutput.decodeNil(_:)`.
+    func decodeNil(_ key: FieldKey) throws -> Bool {
+        try self.row.decodeNil(column: self.adjust(key: key))
+    }
+    
     // See `DatabaseOutput.decode(_:as:)`.
-    func decode<T: Decodable>(_ key: FieldKey, as type: T.Type) throws -> T {
-        try self.row
-            .sql(decoder: self.decoder)
-            .decode(column: self.columnName(key), as: T.self)
-    }
-
-    /// Translates a given `FieldKey` into a column name, accounting for the current schema, if any.
-    private func columnName(_ key: FieldKey) -> String {
-        if let schema = self.schema {
-            return "\(schema)_\(key.description)"
-        } else {
-            return key.description
-        }
+    func decode<T: Decodable>(_ key: FieldKey, as: T.Type) throws -> T {
+        try self.row.decode(column: self.adjust(key: key), as: T.self)
     }
 }


### PR DESCRIPTION
**These changes are now available in [4.6.0](https://github.com/vapor/fluent-mysql-driver/releases/tag/4.6.0)**


Now supports query logging with the same semantics as the other drivers.

Also cleans up some `Sendable` issues and fixes some warnings in the tests.