### PR TITLE
Some minor cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.swift]
+indent_style = space
+indent_size = 4
+tab_width = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   api-breakage:
     if: ${{ github.event_name == 'pull_request' && !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:jammy
+    container: swift:noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,16 +43,16 @@ jobs:
       matrix:
         dbimage:
           - mysql:5.7
-          - mysql:8.0
           - mysql:8.3
+          - mysql:9.2
           - mariadb:10.4
           - mariadb:11
           - percona:8.0
         runner:
           # List is deliberately incomplete; we want to avoid running 50 jobs on every commit
-          - swift:5.9-focal
           - swift:5.10-jammy
-          - swift:6.0-jammy
+          - swift:6.0-noble
+          - swift:6.1-noble
     container: ${{ matrix.runner }}
     runs-on: ubuntu-latest
     services:
@@ -86,8 +86,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - macos-version: macos-14
-            xcode-version: latest
+          - macos-version: macos-15
+            xcode-version: latest-stable
     runs-on: ${{ matrix.macos-version }}
     steps:
       - name: Select latest available Xcode

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,77 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentConditionalCompilationBlocks" : false,
+  "indentSwitchCaseLabels" : false,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "lineBreakAroundMultilineExpressionChainComponents" : false,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : false,
+  "lineBreakBeforeEachGenericRequirement" : false,
+  "lineBreakBetweenDeclarationAttributes" : false,
+  "lineLength" : 150,
+  "maximumBlankLines" : 1,
+  "multiElementCollectionTrailingCommas" : true,
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+    ]
+  },
+  "prioritizeKeepingFunctionOutputTogether" : false,
+  "reflowMultilineStringLiterals" : {
+    "never" : {
+    }
+  },
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : false,
+    "AlwaysUseLiteralForEmptyCollectionInit" : true,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "AvoidRetroactiveConformances" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : false,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileScopedDeclarationPrivacy" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : true,
+    "NeverForceUnwrap" : false,
+    "NeverUseForceTry" : false,
+    "NeverUseImplicitlyUnwrappedOptionals" : false,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoAssignmentInExpressions" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyLinesOpeningClosingBraces" : false,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : false,
+    "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : false,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
+    "UseEarlyExits" : true,
+    "UseExplicitNilCheckInConditions" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "UseWhereClausesInForLoops" : false,
+    "ValidateDocumentationComments" : false
+  },
+  "spacesAroundRangeFormationOperators" : true,
+  "spacesBeforeEndOfLineComments" : 1,
+  "tabWidth" : 4,
+  "version" : 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(
@@ -13,9 +13,9 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.49.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.51.0"),
         .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.9.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vapor/fluent-mysql-driver/assets/1130717/2810939b-2d77-4d39-9485-8e11b8f5dab4">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vapor/fluent-mysql-driver/assets/1130717/ab442fbf-baf1-4cfe-8639-23141fb26e5a">
-  <img src="https://github.com/vapor/fluent-mysql-driver/assets/1130717/ab442fbf-baf1-4cfe-8639-23141fb26e5a" height="96" alt="FluentMySQLDriver">
-</picture> 
+<img src="https://design.vapor.codes/images/vapor-fluentmysqldriver.svg" height="96" alt="FluentMySQLDriver">
 <br>
 <br>
 <a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
@@ -11,7 +7,7 @@
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/fluent-mysql-driver/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/fluent-mysql-driver/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
 <a href="https://codecov.io/github/vapor/fluent-mysql-driver"><img src="https://img.shields.io/codecov/c/github/vapor/fluent-mysql-driver?style=plastic&logo=codecov&label=codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift58up.svg" alt="Swift 5.8+"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+"></a>
 </p>
 
 <br>

--- a/Sources/FluentMySQLDriver/Docs.docc/theme-settings.json
+++ b/Sources/FluentMySQLDriver/Docs.docc/theme-settings.json
@@ -8,11 +8,14 @@
       "mysql-turquoise": "#02758f",
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-mysql-turquoise) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-mysql-turquoise)",
+      "documentation-intro-eyebrow": "white",
+      "documentation-intro-figure": "white",
+      "documentation-intro-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }
     },
-    "icons": { "technology": "/fluentmysqldriver/images/vapor-fluentmysqldriver-logo.svg" }
+    "icons": { "technology": "/fluentmysqldriver/images/FluentMySQLDriver/vapor-fluentmysqldriver-logo.svg" }
   },
   "features": {
     "quickNavigation": { "enable": true },

--- a/Sources/FluentMySQLDriver/FluentMySQLConfiguration.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLConfiguration.swift
@@ -1,8 +1,8 @@
 import AsyncKit
-import struct NIO.TimeAmount
 import FluentKit
-import MySQLKit
 import Logging
+import MySQLKit
+import struct NIO.TimeAmount
 
 extension DatabaseConfigurationFactory {
     /// Create a database configuration factory for connecting to a server through a UNIX domain socket.
@@ -43,7 +43,7 @@ extension DatabaseConfigurationFactory {
             sqlLogLevel: sqlLogLevel
         )
     }
-    
+
     /// Create a database configuration factory from an appropriately formatted URL string.
     ///
     /// - Parameters:
@@ -185,10 +185,10 @@ extension DatabaseConfigurationFactory {
 struct FluentMySQLConfiguration: DatabaseConfiguration {
     /// The underlying `MySQLConfiguration`.
     let configuration: MySQLConfiguration
-    
+
     /// The maximum number of database connections to add to each event loop's pool.
     let maxConnectionsPerEventLoop: Int
-    
+
     /// The timeout for queries on the connection pool's wait list.
     let connectionPoolTimeout: TimeAmount
 
@@ -197,13 +197,13 @@ struct FluentMySQLConfiguration: DatabaseConfiguration {
 
     /// A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
     let decoder: MySQLDataDecoder
-    
+
     /// A logging level used for logging queries.
     let sqlLogLevel: Logger.Level?
-    
+
     // See `DatabaseConfiguration.middleware`.
     var middleware: [any AnyModelMiddleware]
-    
+
     // See `DatabaseConfiguration.makeDriver(for:)`.
     func makeDriver(for databases: Databases) -> any DatabaseDriver {
         let db = MySQLConnectionSource(

--- a/Sources/FluentMySQLDriver/FluentMySQLDriver.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLDriver.swift
@@ -7,16 +7,16 @@ import NIOCore
 struct FluentMySQLDriver: DatabaseDriver {
     /// The connection pool set for this driver.
     let pool: EventLoopGroupConnectionPool<MySQLConnectionSource>
-    
+
     /// A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
     let encoder: MySQLDataEncoder
 
     /// A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
     let decoder: MySQLDataDecoder
-    
+
     /// A logging level used for logging queries.
     let sqlLogLevel: Logger.Level?
-    
+
     // See `DatabaseDriver.makeDatabase(with:)`.
     func makeDatabase(with context: DatabaseContext) -> any Database {
         FluentMySQLDatabase(
@@ -28,12 +28,12 @@ struct FluentMySQLDriver: DatabaseDriver {
             inTransaction: false
         )
     }
-    
+
     // See `DatabaseDriver.shutdown()`.
     func shutdown() {
         try? self.pool.syncShutdownGracefully()
     }
-    
+
     func shutdownAsync() async {
         try? await self.pool.shutdownAsync()
     }

--- a/Sources/FluentMySQLDriver/MySQLConverterDelegate.swift
+++ b/Sources/FluentMySQLDriver/MySQLConverterDelegate.swift
@@ -5,12 +5,12 @@ struct MySQLConverterDelegate: SQLConverterDelegate {
     // See `SQLConverterDelegate.customDataType(_:)`.
     func customDataType(_ dataType: DatabaseSchema.DataType) -> (any SQLExpression)? {
         switch dataType {
-        case .string: return SQLRaw("VARCHAR(255)")
-        case .datetime: return SQLRaw("DATETIME(6)")
-        case .uuid: return SQLRaw("VARBINARY(16)")
-        case .bool: return SQLRaw("BOOL")
-        case .array: return SQLRaw("JSON")
-        default: return nil
+        case .string: SQLRaw("VARCHAR(255)")
+        case .datetime: SQLRaw("DATETIME(6)")
+        case .uuid: SQLRaw("VARBINARY(16)")
+        case .bool: SQLRaw("BOOL")
+        case .array: SQLRaw("JSON")
+        default: nil
         }
     }
 
@@ -30,10 +30,11 @@ struct MySQLConverterDelegate: SQLConverterDelegate {
                     constraints: constraints.filter { constraint in
                         switch constraint {
                         case .foreignKey(let schema, let space, let field, let onDelete, let onUpdate):
-                            copy.createConstraints.append(.constraint(
-                                .foreignKey([name], schema, space: space, [field], onDelete: onDelete, onUpdate: onUpdate),
-                                name: nil
-                            ))
+                            copy.createConstraints.append(
+                                .constraint(
+                                    .foreignKey([name], schema, space: space, [field], onDelete: onDelete, onUpdate: onUpdate),
+                                    name: nil
+                                ))
                             return false
                         default:
                             return true

--- a/Sources/FluentMySQLDriver/MySQLError+Database.swift
+++ b/Sources/FluentMySQLDriver/MySQLError+Database.swift
@@ -1,35 +1,35 @@
-import MySQLNIO
 import FluentKit
+import MySQLNIO
 
 /// Conform `MySQLError` to `DatabaseError`.
 extension MySQLNIO.MySQLError: FluentKit.DatabaseError {
     // See `DatabaseError.isSyntaxError`.
     public var isSyntaxError: Bool {
         switch self {
-            case .invalidSyntax(_):
-                return true
-            default:
-                return false
+        case .invalidSyntax(_):
+            true
+        default:
+            false
         }
     }
 
     // See `DatabaseError.isConstraintFailure`.
     public var isConstraintFailure: Bool {
         switch self {
-            case .duplicateEntry(_):
-                return true
-            default:
-                return false
+        case .duplicateEntry(_):
+            true
+        default:
+            false
         }
     }
 
     // See `DatabaseError.isConnectionClosed`.
     public var isConnectionClosed: Bool {
         switch self {
-            case .closed:
-                return true
-            default:
-                return false
+        case .closed:
+            true
+        default:
+            false
         }
     }
 }

--- a/Sources/FluentMySQLDriver/MySQLRow+Database.swift
+++ b/Sources/FluentMySQLDriver/MySQLRow+Database.swift
@@ -1,10 +1,10 @@
-import MySQLNIO
-import MySQLKit
 import FluentKit
+import MySQLKit
+import MySQLNIO
 
 extension SQLRow {
     /// Returns a `DatabaseOutput` for this row.
-    /// 
+    ///
     /// - Returns: A `DatabaseOutput` instance.
     func databaseOutput() -> any DatabaseOutput {
         SQLRowDatabaseOutput(row: self, schema: nil)
@@ -18,7 +18,7 @@ private struct SQLRowDatabaseOutput: DatabaseOutput {
 
     /// The most recently set schema value (see `DatabaseOutput.schema(_:)`).
     let schema: String?
-    
+
     // See `CustomStringConvertible.description`.
     var description: String {
         String(describing: self.row)
@@ -28,22 +28,22 @@ private struct SQLRowDatabaseOutput: DatabaseOutput {
     private func adjust(key: FieldKey) -> String {
         (self.schema.map { .prefix(.prefix(.string($0), "_"), key) } ?? key).description
     }
-    
+
     // See `DatabaseOutput.schema(_:)`.
     func schema(_ schema: String) -> any DatabaseOutput {
         Self(row: self.row, schema: schema)
     }
-    
+
     // See `DatabaseOutput.contains(_:)`.
     func contains(_ key: FieldKey) -> Bool {
         self.row.contains(column: self.adjust(key: key))
     }
-    
+
     // See `DatabaseOutput.decodeNil(_:)`.
     func decodeNil(_ key: FieldKey) throws -> Bool {
         try self.row.decodeNil(column: self.adjust(key: key))
     }
-    
+
     // See `DatabaseOutput.decode(_:as:)`.
     func decode<T: Decodable>(_ key: FieldKey, as: T.Type) throws -> T {
         try self.row.decode(column: self.adjust(key: key), as: T.self)


### PR DESCRIPTION
**These changes are now available in [4.7.1](https://github.com/vapor/fluent-mysql-driver/releases/tag/4.7.1)**


Simple stuff, really - add a `.swift-format` and use it, bump the minimum Swift version to 5.10, update the CI and the README. you get the idea.