### PR TITLE
Enable use of idle connection pruning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     container: swift:noble
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with: { 'fetch-depth': 0 }
       - name: API breaking changes
         run: |
@@ -44,7 +44,7 @@ jobs:
         dbimage:
           - mysql:5.7
           - mysql:8.3
-          - mysql:9.2
+          - mysql:9.4
           - mariadb:10.4
           - mariadb:11
           - percona:8.0
@@ -71,10 +71,12 @@ jobs:
           MYSQL_PASSWORD: test_password
           MYSQL_DATABASE: test_database
     steps:
+      - name: Ensure curl is available
+        run: apt-get update -y && apt-get install -y curl
       - name: Check out package
-        uses: actions/checkout@v4
-      - name: Run local tests with coverage and TSan
-        run: swift test --enable-code-coverage --sanitize=thread
+        uses: actions/checkout@v5
+      - name: Run local tests with coverage
+        run: swift test --enable-code-coverage
       - name: Submit coverage report to Codecov.io
         uses: vapor/swift-codecov-action@v0.3
         with:
@@ -109,9 +111,9 @@ jobs:
               CREATE DATABASE test_database_b; GRANT ALL PRIVILEGES ON test_database_b.* TO test_username@localhost;
           SQL
       - name: Check out code
-        uses: actions/checkout@v4
-      - name: Run tests with Thread Sanitizer
-        run: swift test --sanitize=thread
+        uses: actions/checkout@v5
+      - name: Run tests
+        run: swift test
         env: 
           MYSQL_HOSTNAME_A: '127.0.0.1'
           MYSQL_HOSTNAME_B: '127.0.0.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,8 @@ jobs:
           - mysql:5.7
           - mysql:8.3
           - mysql:9.4
-          - mariadb:10.4
-          - mariadb:11
+          - mariadb:10.6
+          - mariadb:12
           - percona:8.0
         runner:
           # List is deliberately incomplete; we want to avoid running 50 jobs on every commit

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,10 @@ let package = Package(
         .library(name: "FluentMySQLDriver", targets: ["FluentMySQLDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.51.0"),
-        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.9.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.52.2"),
+        .package(url: "https://github.com/vapor/mysql-kit.git", from: "4.10.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.21.0"),
     ],
     targets: [
         .target(
@@ -25,6 +26,7 @@ let package = Package(
                 .product(name: "FluentSQL", package: "fluent-kit"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "MySQLKit", package: "mysql-kit"),
+                .product(name: "AsyncKit", package: "async-kit"),
             ],
             swiftSettings: swiftSettings
         ),
@@ -41,6 +43,7 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
     .enableUpcomingFeature("DisableOutwardActorInference"),

--- a/Sources/FluentMySQLDriver/FluentMySQLConfiguration.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLConfiguration.swift
@@ -16,6 +16,7 @@ extension DatabaseConfigurationFactory {
     ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
     ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
     ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
     /// - Returns: An appropriate configuration factory.
     public static func mysql(
         unixDomainSocketPath: String,
@@ -24,7 +25,185 @@ extension DatabaseConfigurationFactory {
         database: String? = nil,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
-        pruneInterval: TimeAmount? = nil,
+        encoder: MySQLDataEncoder = .init(),
+        decoder: MySQLDataDecoder = .init(),
+        sqlLogLevel: Logger.Level? = .debug
+    ) throws -> Self {
+        try .mysql(
+            unixDomainSocketPath: unixDomainSocketPath,
+            username: username,
+            password: password,
+            database: database,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: nil,
+            encoder: encoder,
+            decoder: decoder,
+            sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    /// Create a database configuration factory from an appropriately formatted URL string.
+    ///
+    /// - Parameters:
+    ///   - url: A URL-formatted MySQL connection string. See `MySQLConfiguration` in MySQLKit for details of
+    ///     accepted URL formats.
+    ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
+    ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///     Defaults to 2 minutes. Ignored if `pruneInterval` is `nil`.
+    ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
+    ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
+    /// - Returns: An appropriate configuration factory.
+    public static func mysql(
+        url urlString: String,
+        maxConnectionsPerEventLoop: Int = 1,
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        encoder: MySQLDataEncoder = .init(),
+        decoder: MySQLDataDecoder = .init(),
+        sqlLogLevel: Logger.Level? = .debug
+    ) throws -> Self {
+        try .mysql(
+            url: urlString,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: nil,
+            encoder: encoder,
+            decoder: decoder,
+            sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    /// Create a database configuration factory from an appropriately formatted URL string.
+    ///
+    /// - Parameters:
+    ///   - url: A `URL` containing MySQL connection parameters. See `MySQLConfiguration` in MySQLKit for details of
+    ///     accepted URL formats.
+    ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
+    ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
+    ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
+    /// - Returns: An appropriate configuration factory.
+    public static func mysql(
+        url: URL,
+        maxConnectionsPerEventLoop: Int = 1,
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        encoder: MySQLDataEncoder = .init(),
+        decoder: MySQLDataDecoder = .init(),
+        sqlLogLevel: Logger.Level? = .debug
+    ) throws -> Self {
+        try .mysql(
+            url: url,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: nil,
+            encoder: encoder,
+            decoder: decoder,
+            sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    /// Create a database configuration factory for connecting to a server with a hostname and optional port.
+    ///
+    /// - Parameters:
+    ///   - hostname: The hostname to connect to.
+    ///   - port: A TCP port number to connect on. Defaults to the IANA-assigned MySQL port number (3306).
+    ///   - username: The username to use for the connection.
+    ///   - password: The password (empty string for none) to use for the connection.
+    ///   - database: The default database for the connection, if any.
+    ///   - tlsConfiguration: An optional `TLSConfiguration` specifying encryption for the connection.
+    ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
+    ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
+    ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
+    /// - Returns: An appropriate configuration factory.
+    public static func mysql(
+        hostname: String,
+        port: Int = 3306,
+        username: String,
+        password: String,
+        database: String? = nil,
+        tlsConfiguration: TLSConfiguration? = .makeClientConfiguration(),
+        maxConnectionsPerEventLoop: Int = 1,
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        encoder: MySQLDataEncoder = .init(),
+        decoder: MySQLDataDecoder = .init(),
+        sqlLogLevel: Logger.Level? = .debug
+    ) -> Self {
+        .mysql(
+            hostname: hostname,
+            port: port,
+            username: username,
+            password: password,
+            database: database,
+            tlsConfiguration: tlsConfiguration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: nil,
+            encoder: encoder,
+            decoder: decoder,
+            sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    /// Create a database configuration factory for connecting to a server with a given `MySQLConfiguration`.
+    ///
+    /// - Parameters:
+    ///   - configuration: A connection configuration.
+    ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
+    ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
+    ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
+    /// - Returns: An appropriate configuration factory.
+    public static func mysql(
+        configuration: MySQLConfiguration,
+        maxConnectionsPerEventLoop: Int = 1,
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        encoder: MySQLDataEncoder = .init(),
+        decoder: MySQLDataDecoder = .init(),
+        sqlLogLevel: Logger.Level? = .debug
+    ) -> Self {
+        .mysql(
+            configuration: configuration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: nil,
+            encoder: encoder,
+            decoder: decoder,
+            sqlLogLevel: sqlLogLevel
+        )
+    }
+}
+
+extension DatabaseConfigurationFactory {
+    /// Create a database configuration factory for connecting to a server through a UNIX domain socket.
+    ///
+    /// - Parameters:
+    ///   - unixDomainSocketPath: The path to the UNIX domain socket to connect through.
+    ///   - username: The username to use for the connection.
+    ///   - password: The password (empty string for none) to use for the connection.
+    ///   - database: The default database for the connection, if any.
+    ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
+    ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///   - pruneInterval: How often to check for and prune idle database connections. If `nil` (the default),
+    ///     no pruning is performed.
+    ///   - maxIdleTimeBeforePruning: How long a connection may remain idle before being pruned, if pruning is enabled.
+    ///     Defaults to 2 minutes. Ignored if `pruneInterval` is `nil`.
+    ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
+    ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
+    /// - Returns: An appropriate configuration factory.
+    public static func mysql(
+        unixDomainSocketPath: String,
+        username: String,
+        password: String,
+        database: String? = nil,
+        maxConnectionsPerEventLoop: Int = 1,
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        pruneInterval: TimeAmount?,
         maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
@@ -55,14 +234,19 @@ extension DatabaseConfigurationFactory {
     ///     accepted URL formats.
     ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
     ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///   - pruneInterval: How often to check for and prune idle database connections. If `nil` (the default),
+    ///     no pruning is performed.
+    ///   - maxIdleTimeBeforePruning: How long a connection may remain idle before being pruned, if pruning is enabled.
+    ///     Defaults to 2 minutes. Ignored if `pruneInterval` is `nil`.
     ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
     ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
     /// - Returns: An appropriate configuration factory.
     public static func mysql(
         url urlString: String,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
-        pruneInterval: TimeAmount? = nil,
+        pruneInterval: TimeAmount?,
         maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
@@ -90,14 +274,19 @@ extension DatabaseConfigurationFactory {
     ///     accepted URL formats.
     ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
     ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///   - pruneInterval: How often to check for and prune idle database connections. If `nil` (the default),
+    ///     no pruning is performed.
+    ///   - maxIdleTimeBeforePruning: How long a connection may remain idle before being pruned, if pruning is enabled.
+    ///     Defaults to 2 minutes. Ignored if `pruneInterval` is `nil`.
     ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
     ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
     /// - Returns: An appropriate configuration factory.
     public static func mysql(
         url: URL,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
-        pruneInterval: TimeAmount? = nil,
+        pruneInterval: TimeAmount?,
         maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
@@ -129,8 +318,13 @@ extension DatabaseConfigurationFactory {
     ///   - tlsConfiguration: An optional `TLSConfiguration` specifying encryption for the connection.
     ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
     ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///   - pruneInterval: How often to check for and prune idle database connections. If `nil` (the default),
+    ///     no pruning is performed.
+    ///   - maxIdleTimeBeforePruning: How long a connection may remain idle before being pruned, if pruning is enabled.
+    ///     Defaults to 2 minutes. Ignored if `pruneInterval` is `nil`.
     ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
     ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
     /// - Returns: An appropriate configuration factory.
     public static func mysql(
         hostname: String,
@@ -141,7 +335,7 @@ extension DatabaseConfigurationFactory {
         tlsConfiguration: TLSConfiguration? = .makeClientConfiguration(),
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
-        pruneInterval: TimeAmount? = nil,
+        pruneInterval: TimeAmount?,
         maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
@@ -172,14 +366,19 @@ extension DatabaseConfigurationFactory {
     ///   - configuration: A connection configuration.
     ///   - maxConnectionsPerEventLoop: The maximum number of database connections to add to each event loop's pool.
     ///   - connectionPoolTimeout: The timeout for queries on the connection pool's wait list.
+    ///   - pruneInterval: How often to check for and prune idle database connections. If `nil` (the default),
+    ///     no pruning is performed.
+    ///   - maxIdleTimeBeforePruning: How long a connection may remain idle before being pruned, if pruning is enabled.
+    ///     Defaults to 2 minutes. Ignored if `pruneInterval` is `nil`.
     ///   - encoder: A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
     ///   - decoder: A `MySQLDataDecoder` used to translate `MySQLData` values into output values in `SQLRow`s.
+    ///   - sqlLogLevel: The log level to use for logging serialized queries issued to databases using this configuration.
     /// - Returns: An appropriate configuration factory.
     public static func mysql(
         configuration: MySQLConfiguration,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
-        pruneInterval: TimeAmount? = nil,
+        pruneInterval: TimeAmount?,
         maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),

--- a/Sources/FluentMySQLDriver/FluentMySQLConfiguration.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLConfiguration.swift
@@ -24,6 +24,8 @@ extension DatabaseConfigurationFactory {
         database: String? = nil,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        pruneInterval: TimeAmount? = nil,
+        maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
         sqlLogLevel: Logger.Level? = .debug
@@ -38,6 +40,8 @@ extension DatabaseConfigurationFactory {
             configuration: configuration,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
             connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: pruneInterval,
+            maxIdleTimeBeforePruning: maxIdleTimeBeforePruning,
             encoder: encoder,
             decoder: decoder,
             sqlLogLevel: sqlLogLevel
@@ -58,6 +62,8 @@ extension DatabaseConfigurationFactory {
         url urlString: String,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        pruneInterval: TimeAmount? = nil,
+        maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
         sqlLogLevel: Logger.Level? = .debug
@@ -69,6 +75,8 @@ extension DatabaseConfigurationFactory {
             url: url,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
             connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: pruneInterval,
+            maxIdleTimeBeforePruning: maxIdleTimeBeforePruning,
             encoder: encoder,
             decoder: decoder,
             sqlLogLevel: sqlLogLevel
@@ -89,6 +97,8 @@ extension DatabaseConfigurationFactory {
         url: URL,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        pruneInterval: TimeAmount? = nil,
+        maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
         sqlLogLevel: Logger.Level? = .debug
@@ -100,6 +110,8 @@ extension DatabaseConfigurationFactory {
             configuration: configuration,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
             connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: pruneInterval,
+            maxIdleTimeBeforePruning: maxIdleTimeBeforePruning,
             encoder: encoder,
             decoder: decoder,
             sqlLogLevel: sqlLogLevel
@@ -129,6 +141,8 @@ extension DatabaseConfigurationFactory {
         tlsConfiguration: TLSConfiguration? = .makeClientConfiguration(),
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        pruneInterval: TimeAmount? = nil,
+        maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
         sqlLogLevel: Logger.Level? = .debug
@@ -144,6 +158,8 @@ extension DatabaseConfigurationFactory {
             ),
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
             connectionPoolTimeout: connectionPoolTimeout,
+            pruneInterval: pruneInterval,
+            maxIdleTimeBeforePruning: maxIdleTimeBeforePruning,
             encoder: encoder,
             decoder: decoder,
             sqlLogLevel: sqlLogLevel
@@ -163,6 +179,8 @@ extension DatabaseConfigurationFactory {
         configuration: MySQLConfiguration,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        pruneInterval: TimeAmount? = nil,
+        maxIdleTimeBeforePruning: TimeAmount = .seconds(120),
         encoder: MySQLDataEncoder = .init(),
         decoder: MySQLDataDecoder = .init(),
         sqlLogLevel: Logger.Level? = .debug
@@ -172,6 +190,8 @@ extension DatabaseConfigurationFactory {
                 configuration: configuration,
                 maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
                 connectionPoolTimeout: connectionPoolTimeout,
+                pruningInterval: pruneInterval,
+                maxIdleTimeBeforePruning: maxIdleTimeBeforePruning,
                 encoder: encoder,
                 decoder: decoder,
                 sqlLogLevel: sqlLogLevel,
@@ -191,6 +211,12 @@ struct FluentMySQLConfiguration: DatabaseConfiguration {
 
     /// The timeout for queries on the connection pool's wait list.
     let connectionPoolTimeout: TimeAmount
+
+    /// The idle pruning interval for the connection pool.
+    let pruningInterval: TimeAmount?
+
+    /// The connection idle timeout for the connection pool.
+    let maxIdleTimeBeforePruning: TimeAmount
 
     /// A `MySQLDataEncoder` used to translate bound query parameters into `MySQLData` values.
     let encoder: MySQLDataEncoder
@@ -213,6 +239,8 @@ struct FluentMySQLConfiguration: DatabaseConfiguration {
             source: db,
             maxConnectionsPerEventLoop: self.maxConnectionsPerEventLoop,
             requestTimeout: self.connectionPoolTimeout,
+            pruneInterval: self.pruningInterval,
+            maxIdleTimeBeforePruning: self.maxIdleTimeBeforePruning,
             on: databases.eventLoopGroup
         )
         return FluentMySQLDriver(

--- a/Sources/FluentMySQLDriver/FluentMySQLDatabase.swift
+++ b/Sources/FluentMySQLDriver/FluentMySQLDatabase.swift
@@ -69,12 +69,12 @@ struct FluentMySQLDatabase: Database, SQLDatabase, MySQLDatabase {
     }
 
     // See `Database.transaction(_:)`.
-    func transaction<T>(_ closure: @escaping @Sendable (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+    func transaction<T: Sendable>(_ closure: @escaping @Sendable (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         self.inTransaction ? closure(self) : self.eventLoop.makeFutureWithTask { try await self.transaction { try await closure($0).get() } }
     }
 
     // See `Database.transaction(_:)`.
-    func transaction<T>(_ closure: @escaping @Sendable (any Database) async throws -> T) async throws -> T {
+    func transaction<T: Sendable>(_ closure: @escaping @Sendable (any Database) async throws -> T) async throws -> T {
         guard !self.inTransaction else {
             return try await closure(self)
         }
@@ -144,7 +144,7 @@ struct FluentMySQLDatabase: Database, SQLDatabase, MySQLDatabase {
     }
 
     // See `SQLDatabase.withSession(_:)`.
-    func withSession<R>(_ closure: @escaping @Sendable (any SQLDatabase) async throws -> R) async throws -> R {
+    func withSession<R: Sendable>(_ closure: @escaping @Sendable (any SQLDatabase) async throws -> R) async throws -> R {
         try await self.withConnection { (conn: MySQLConnection) in
             conn.eventLoop.makeFutureWithTask {
                 try await closure(conn.sql(encoder: self.encoder, decoder: self.decoder, queryLogLevel: self.queryLogLevel))

--- a/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
+++ b/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
@@ -463,6 +463,23 @@ final class FluentMySQLDriverTests: XCTestCase {
         await XCTAssertEqualAsync(try await self.db.transaction { try await ($0 as! FluentMySQLDatabase).transaction { _ in 1 } }, 1)
     }
 
+    func testCoverageOfConfigMethods() throws {
+        XCTAssertTrue(try DatabaseConfigurationFactory.mysql(unixDomainSocketPath: "/", username: "", password: "", database: "", maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, pruneInterval: nil, maxIdleTimeBeforePruning: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+        XCTAssertTrue(try DatabaseConfigurationFactory.mysql(unixDomainSocketPath: "/", username: "", password: "", database: "", maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+
+        XCTAssertTrue(try DatabaseConfigurationFactory.mysql(url: "mysql://u:p@h:1/d", maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, pruneInterval: nil, maxIdleTimeBeforePruning: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+        XCTAssertTrue(try DatabaseConfigurationFactory.mysql(url: "mysql://u:p@h:1/d", maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+
+        XCTAssertTrue(try DatabaseConfigurationFactory.mysql(url: URL(string: "mysql://u:p@h:1/d")!, maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, pruneInterval: nil, maxIdleTimeBeforePruning: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+        XCTAssertTrue(try DatabaseConfigurationFactory.mysql(url: URL(string: "mysql://u:p@h:1/d")!, maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+
+        XCTAssertTrue(DatabaseConfigurationFactory.mysql(hostname: "", port: 0, username: "", password: "", database: "", tlsConfiguration: nil, maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, pruneInterval: nil, maxIdleTimeBeforePruning: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+        XCTAssertTrue(DatabaseConfigurationFactory.mysql(hostname: "", port: 0, username: "", password: "", database: "", tlsConfiguration: nil, maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+
+        XCTAssertTrue(DatabaseConfigurationFactory.mysql(configuration: .init(hostname: "", port: 0, username: "", password: "", database: "", tlsConfiguration: nil), maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, pruneInterval: nil, maxIdleTimeBeforePruning: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+        XCTAssertTrue(DatabaseConfigurationFactory.mysql(configuration: .init(hostname: "", port: 0, username: "", password: "", database: "", tlsConfiguration: nil), maxConnectionsPerEventLoop: 0, connectionPoolTimeout: .zero, encoder: .init(), decoder: .init(), sqlLogLevel: .debug).make().middleware.isEmpty)
+    }
+
     var benchmarker: FluentBenchmarker { .init(databases: self.dbs) }
     var eventLoopGroup: any EventLoopGroup { MultiThreadedEventLoopGroup.singleton }
     var threadPool: NIOThreadPool { NIOThreadPool.singleton }

--- a/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
+++ b/Tests/FluentMySQLDriverTests/FluentMySQLDriverTests.swift
@@ -488,7 +488,9 @@ final class FluentMySQLDriverTests: XCTestCase {
                 password: env("MYSQL_PASSWORD_A") ?? "test_password",
                 database: databaseA,
                 tlsConfiguration: tls,
-                connectionPoolTimeout: .seconds(10)
+                connectionPoolTimeout: .seconds(10),
+                pruneInterval: .seconds(30),
+                maxIdleTimeBeforePruning: .seconds(60)
             ), as: .a)
 
         self.dbs.use(
@@ -499,7 +501,9 @@ final class FluentMySQLDriverTests: XCTestCase {
                 password: env("MYSQL_PASSWORD_B") ?? "test_password",
                 database: databaseB,
                 tlsConfiguration: tls,
-                connectionPoolTimeout: .seconds(10)
+                connectionPoolTimeout: .seconds(10),
+                pruneInterval: .seconds(30),
+                maxIdleTimeBeforePruning: .seconds(60)
             ), as: .b)
     }
 


### PR DESCRIPTION
**These changes are now available in [4.8.0](https://github.com/vapor/fluent-mysql-driver/releases/tag/4.8.0)**


[AsyncKit 1.21.0](https://github.com/vapor/async-kit/releases/1.21.0) added support for automatic pruning of idle database connections in the connection pool. This PR adds the necessary configuration parameters to the MySQL driver, enabling Fluent users to take advantage of this new functionality:

```swift
app.databases.use(.mysql(
    url: "mysql://user@pass:host/db",
    pruningInterval: .minutes(1),
    maxIdleTimeBeforePruning: .minutes(10)
), as: .mysql)
```

The `pruningInterval` controls how often the pool will check for idle connections; specifying `nil` disables idle pruning entirely. The `maxIdleTimeBeforePruning` controls how long a connection must go unused before being pruned.